### PR TITLE
New ortho layout

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/component-wrappers.js
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers.js
@@ -1,5 +1,0 @@
-import SiteHeader from './components/SiteHeader';
-
-export default {
-  SiteHeader: () => SiteHeader
-}

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers.ts
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers.ts
@@ -1,0 +1,5 @@
+import { OrthoMCLPage } from './components/layout/OrthoMCLPage';
+
+export default {
+  Page: () => OrthoMCLPage
+};

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.scss
@@ -17,4 +17,8 @@
       height: 5em;
     }
   }
+
+  .wdk-CheckboxTreeNodeWrapper {
+    position: relative;
+  }
 }

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.scss
@@ -1,0 +1,20 @@
+@import 'ebrc-client/styles/breakpoints.scss';
+@import 'ebrc-client/styles/default-layout.scss';
+@import 'ebrc-client/styles/header.scss';
+@import 'ebrc-client/styles/announcements.scss';
+@import 'ebrc-client/styles/main.scss';
+@import 'ebrc-client/styles/footer.scss';
+
+.vpdb-Header {
+  background-color: #414c9b;
+
+  .vpdb-HeaderBranding {
+    content: url('~site/images/OrthoMCL/title_s.png');
+  }
+
+  @media screen and (min-width: $cramped-header-width + 1) {
+    .vpdb-HeaderBranding {
+      height: 5em;
+    }
+  }
+}

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.scss
@@ -7,6 +7,7 @@
 
 .vpdb-Header {
   background-color: #414c9b;
+  z-index: 100;
 
   .vpdb-HeaderBranding {
     content: url('~site/images/OrthoMCL/title_s.png');

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -1,0 +1,71 @@
+import React, { FunctionComponent, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { noop } from 'lodash';
+
+import { Link } from 'wdk-client/Components';
+import { Props } from 'wdk-client/Components/Layout/Page';
+import { ErrorBoundary } from 'wdk-client/Controllers';
+import { RootState } from 'wdk-client/Core/State/Types';
+import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
+
+import Announcements from 'ebrc-client/components/Announcements';
+import CookieBanner from 'ebrc-client/components/CookieBanner';
+import { Footer } from 'ebrc-client/components/homepage/Footer';
+import { Header } from 'ebrc-client/components/homepage/Header';
+import { Main } from 'ebrc-client/components/homepage/Main';
+
+import './OrthoMCLPage.scss';
+
+const cx = makeClassNameHelper('vpdb-');
+
+export const OrthoMCLPage: FunctionComponent<Props> = props => {
+  const buildNumber = useSelector((state: RootState) => state.globalData.config?.buildNumber);
+  const releaseDate = useSelector((state: RootState) => state.globalData.config?.releaseDate);
+  const displayName = useSelector((state: RootState) => state.globalData.config?.displayName);
+
+  const menuItems = useMemo(() => [], []);
+  const closedBanners = useMemo(() => [], []);
+
+  const branding = (
+    <Link to="/">
+      <div className="vpdb-HeaderBranding">
+      </div>
+    </Link>
+  );
+
+  return (
+    <div className={cx('RootContainer', props.classNameModifier)}>
+      <ErrorBoundary>
+        <Header
+          menuItems={menuItems}
+          containerClassName={cx('Header', 'expanded')}
+          onShowAnnouncements={noop}
+          showAnnouncementsToggle={false}
+          branding={branding}
+        />
+      </ErrorBoundary>
+      <div className={cx('Announcements')}>
+        <Announcements
+          closedBanners={closedBanners}
+          setClosedBanners={noop}
+        />
+      </div>
+      <Main containerClassName={cx('Main')}>
+        {props.children}
+      </Main>
+      <ErrorBoundary>
+        <Footer
+          containerClassName={cx('Footer')}
+          buildNumber={buildNumber}
+          releaseDate={releaseDate}
+          displayName={displayName}
+        >
+        </Footer>
+      </ErrorBoundary>
+      <ErrorBoundary>
+        <CookieBanner/>
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useCallback, useEffect, useMemo } from 'react';
+import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 
@@ -41,6 +41,8 @@ export const OrthoMCLPage: FunctionComponent<Props> = props => {
     onShowAnnouncements
   } = useAnnouncements();
 
+  const isHeaderExpanded = useCollapisbleHeader();
+
   const branding = (
     <Link to="/">
       <div className="vpdb-HeaderBranding">
@@ -53,7 +55,7 @@ export const OrthoMCLPage: FunctionComponent<Props> = props => {
       <ErrorBoundary>
         <Header
           menuItems={menuItems}
-          containerClassName={cx('Header', 'expanded')}
+          containerClassName={cx('Header', isHeaderExpanded ? 'expanded' : 'collapsed')}
           onShowAnnouncements={onShowAnnouncements}
           showAnnouncementsToggle={showAnnouncementsToggle}
           branding={branding}
@@ -97,6 +99,28 @@ function useHomePageTitle() {
       document.title = displayName;
     }
   }, [ isHomePage, displayName ]);
+}
+
+function useCollapisbleHeader() {
+  const [ isHeaderExpanded, setIsHeaderExpanded ] = useState(true);
+
+  const updateHeader = useCallback(() => {
+    setIsHeaderExpanded(document.body.scrollTop <= 80 && document.documentElement.scrollTop <= 80);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('scroll', updateHeader, { passive: true });
+    window.addEventListener('touch', updateHeader, { passive: true });
+    window.addEventListener('wheel', updateHeader, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', updateHeader);
+      window.removeEventListener('touch', updateHeader);
+      window.removeEventListener('wheel', updateHeader);
+    };
+  }, [ updateHeader ]);
+
+  return isHeaderExpanded;
 }
 
 function useHeaderMenuItems() {

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -2,16 +2,11 @@ import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } f
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
 
-import { get, memoize } from 'lodash';
-
 import { Link } from 'wdk-client/Components';
 import { Props } from 'wdk-client/Components/Layout/Page';
 import { ErrorBoundary } from 'wdk-client/Controllers';
 import { RootState } from 'wdk-client/Core/State/Types';
-import { useSessionBackedState } from 'wdk-client/Hooks/SessionBackedState';
-import { CategoryTreeNode } from 'wdk-client/Utils/CategoryUtils';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
-import { decode, string, arrayOf } from 'wdk-client/Utils/Json';
 
 import Announcements from 'ebrc-client/components/Announcements';
 import CookieBanner from 'ebrc-client/components/CookieBanner';
@@ -21,6 +16,12 @@ import { Header, HeaderMenuItem } from 'ebrc-client/components/homepage/Header';
 import { Main } from 'ebrc-client/components/homepage/Main';
 import { useAnnouncementsState } from 'ebrc-client/hooks/announcements';
 import { STATIC_ROUTE_PATH } from 'ebrc-client/routes';
+
+import {
+  useSearchTree,
+  useSessionBackedSearchTerm,
+  useSessionBackedExpandedBranches
+} from '../../hooks/searchCheckboxTree';
 
 import './OrthoMCLPage.scss';
 
@@ -124,20 +125,14 @@ function useCollapsibleHeader() {
 }
 
 function useHeaderMenuItems() {
-  const searchTree = useSelector(
-    (state: RootState) => get(state.globalData, 'searchTree') as CategoryTreeNode
-  );
-  const [ searchTerm, setSearchTerm ] = useSessionBackedState(
+  const searchTree = useSearchTree();
+  const [ searchTerm, setSearchTerm ] = useSessionBackedSearchTerm(
     '',
-    SEARCH_TERM_SESSION_KEY,
-    encodeSearchTerm,
-    parseSearchTerm
+    SEARCH_TERM_SESSION_KEY
   );
-  const [ expandedBranches, setExpandedBranches ] = useSessionBackedState(
+  const [ expandedBranches, setExpandedBranches ] = useSessionBackedExpandedBranches(
     [],
-    EXPANDED_BRANCHES_SESSION_KEY,
-    encodeExpandedBranches,
-    parseExpandedBranches
+    EXPANDED_BRANCHES_SESSION_KEY
   );
 
   const searchTreeNode = useMemo(
@@ -286,15 +281,6 @@ function makeTodoItem(key: string): HeaderMenuItem {
     type: 'custom'
   };
 }
-
-const encodeSearchTerm = (s: string) => s;
-const parseSearchTerm = encodeSearchTerm;
-
-const encodeExpandedBranches = JSON.stringify;
-const parseExpandedBranches = memoize((s: string) => decode(
-  arrayOf(string),
-  s
-));
 
 function makeStaticPageRoute(url: string) {
   return `${STATIC_ROUTE_PATH}${url}`;

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -108,7 +108,26 @@ function useHeaderMenuItems() {
         key: 'my-workspace',
         display: 'My Workspace',
         type: 'subMenu',
-        items: [ makeTodoItem('workspace-content') ]
+        items: [
+          {
+            key: 'galaxy-analyses',
+            display: 'Analyze my data (Galaxy)',
+            type: 'reactRoute',
+            url: '/galaxy-orientation'
+          },
+          {
+            key: 'basket',
+            display: 'Basket',
+            type: 'reactRoute',
+            url: '/workspace/basket'
+          },
+          {
+            key: 'favorites',
+            display: 'Favorites',
+            type: 'reactRoute',
+            url: '/workspace/favorites',
+          }
+        ]
       },
       {
         key: 'tools',

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -32,6 +32,8 @@ const EXPANDED_BRANCHES_SESSION_KEY = 'homepage-header-expanded-branch-ids';
 export const OrthoMCLPage: FunctionComponent<Props> = props => {
   useHomePageTitle();
 
+  const isHeaderExpanded = useCollapsibleHeader();
+
   const menuItems = useHeaderMenuItems();
 
   const {
@@ -40,8 +42,6 @@ export const OrthoMCLPage: FunctionComponent<Props> = props => {
     showAnnouncementsToggle,
     onShowAnnouncements
   } = useAnnouncements();
-
-  const isHeaderExpanded = useCollapisbleHeader();
 
   const branding = (
     <Link to="/">
@@ -101,7 +101,7 @@ function useHomePageTitle() {
   }, [ isHomePage, displayName ]);
 }
 
-function useCollapisbleHeader() {
+function useCollapsibleHeader() {
   const [ isHeaderExpanded, setIsHeaderExpanded ] = useState(true);
 
   const updateHeader = useCallback(() => {

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -14,6 +14,7 @@ import { Footer } from 'ebrc-client/components/homepage/Footer';
 import { Header, HeaderMenuItem } from 'ebrc-client/components/homepage/Header';
 import { Main } from 'ebrc-client/components/homepage/Main';
 import { useAnnouncementsState } from 'ebrc-client/hooks/announcements';
+import { STATIC_ROUTE_PATH } from 'ebrc-client/routes';
 
 import './OrthoMCLPage.scss';
 
@@ -133,13 +134,58 @@ function useHeaderMenuItems() {
         key: 'tools',
         display: 'Tools',
         type: 'subMenu',
-        items: [ makeTodoItem('tools-content') ]
+        items: [
+          {
+            key: 'blast',
+            display: 'BLAST',
+            type: 'reactRoute',
+            url: '/search/sequence/ByBlast'
+          },
+          {
+            key: 'proteome-upload',
+            display: 'Assign your proteins to groups - TODO',
+            type: 'reactRoute',
+            url: '/proteome-upload'
+          },
+          {
+            key: 'downloads',
+            display: 'Download OrthoMCL software',
+            type: 'reactRoute',
+            url: '/downloads'
+          },
+          {
+            key: 'web-services',
+            display: 'Web services',
+            type: 'reactRoute',
+            url: makeStaticPageRoute(`/content/OrthoMCL/webServices.html`)
+          },
+          {
+            key: 'publications',
+            display: 'Publications mentioning OrthoMCL',
+            type: 'externalLink',
+            target: '_blank',
+            url: 'http://scholar.google.com/scholar?as_q=&num=10&as_epq=&as_oq=OrthoMCL&as_eq=encrypt+cryptography+hymenoptera&as_occt=any&as_sauthors=&as_publication=&as_ylo=&as_yhi=&as_sdt=1.&as_sdtp=on&as_sdtf=&as_sdts=39&btnG=Search+Scholar&hl=en'
+          }
+        ]
       },
       {
         key: 'data',
         display: 'Data',
         type: 'subMenu',
-        items: [ makeTodoItem('data-content') ]
+        items: [
+          {
+            key: 'genome-statistics',
+            display: 'Genome Statistics - TODO',
+            type: 'reactRoute',
+            url: '/genome-statistics'
+          },
+          {
+            key: 'genome-sources',
+            display: 'Genome Sources - TODO',
+            type: 'reactRoute',
+            url: '/genome-sources'
+          }
+        ]
       },
       {
         key: 'help',
@@ -149,7 +195,7 @@ function useHeaderMenuItems() {
       },
       {
         key: 'about',
-        display: 'Data',
+        display: 'About',
         type: 'subMenu',
         items: [ makeTodoItem('about-content') ]
       },
@@ -171,6 +217,10 @@ function makeTodoItem(key: string): HeaderMenuItem {
     display: <div>TODO</div>,
     type: 'custom'
   };
+}
+
+function makeStaticPageRoute(url: string) {
+  return `${STATIC_ROUTE_PATH}${url}`;
 }
 
 function useAnnouncements() {

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -11,7 +11,7 @@ import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
 import Announcements from 'ebrc-client/components/Announcements';
 import CookieBanner from 'ebrc-client/components/CookieBanner';
 import { Footer } from 'ebrc-client/components/homepage/Footer';
-import { Header } from 'ebrc-client/components/homepage/Header';
+import { Header, HeaderMenuItem } from 'ebrc-client/components/homepage/Header';
 import { Main } from 'ebrc-client/components/homepage/Main';
 import { useAnnouncementsState } from 'ebrc-client/hooks/announcements';
 
@@ -26,7 +26,7 @@ export const OrthoMCLPage: FunctionComponent<Props> = props => {
   const buildNumber = useBuildNumber();
   const releaseDate = useReleaseDate();
 
-  const menuItems = useMemo(() => [], []);
+  const menuItems = useHeaderMenuItems();
 
   const {
     closedBanners,
@@ -104,6 +104,71 @@ function useHomePageTitle() {
       document.title = displayName;
     }
   }, [ isHomePage, displayName ]);
+}
+
+function useHeaderMenuItems() {
+  return useMemo(() => {
+    const menuItems: HeaderMenuItem[] = [
+      {
+        key: 'my-strategies',
+        display: 'My Strategies',
+        type: 'reactRoute',
+        url: '/workspace/strategies'
+      },
+      {
+        key: 'searches',
+        display: 'Searches',
+        type: 'subMenu',
+        items: [ makeTodoItem('searches-content') ]
+      },
+      {
+        key: 'my-workspace',
+        display: 'My Workspace',
+        type: 'subMenu',
+        items: [ makeTodoItem('workspace-content') ]
+      },
+      {
+        key: 'tools',
+        display: 'Tools',
+        type: 'subMenu',
+        items: [ makeTodoItem('tools-content') ]
+      },
+      {
+        key: 'data',
+        display: 'Data',
+        type: 'subMenu',
+        items: [ makeTodoItem('data-content') ]
+      },
+      {
+        key: 'help',
+        display: 'Help',
+        type: 'subMenu',
+        items: [ makeTodoItem('help-content') ]
+      },
+      {
+        key: 'about',
+        display: 'Data',
+        type: 'subMenu',
+        items: [ makeTodoItem('about-content') ]
+      },
+      {
+        key: 'contact-us',
+        display: 'Contact Us',
+        type: 'reactRoute',
+        url: '/contact-us'
+      }
+    ];
+
+    return menuItems;
+  }, []);
+}
+
+function makeTodoItem(key: string): HeaderMenuItem {
+  return {
+    key,
+    display: <div>TODO</div>,
+    type: 'custom'
+  };
 }
 
 function useAnnouncements() {

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -27,8 +27,8 @@ import './OrthoMCLPage.scss';
 
 const cx = makeClassNameHelper('vpdb-');
 
-const SEARCH_TERM_SESSION_KEY = 'homepage-header-search-term';
-const EXPANDED_BRANCHES_SESSION_KEY = 'homepage-header-expanded-branch-ids';
+const SEARCH_TERM_SESSION_KEY = 'header-search-term';
+const EXPANDED_BRANCHES_SESSION_KEY = 'header-expanded-branch-ids';
 
 export const OrthoMCLPage: FunctionComponent<Props> = props => {
   useHomePageTitle();

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -22,10 +22,6 @@ const cx = makeClassNameHelper('vpdb-');
 export const OrthoMCLPage: FunctionComponent<Props> = props => {
   useHomePageTitle();
 
-  const displayName = useDisplayName();
-  const buildNumber = useBuildNumber();
-  const releaseDate = useReleaseDate();
-
   const menuItems = useHeaderMenuItems();
 
   const {
@@ -63,12 +59,7 @@ export const OrthoMCLPage: FunctionComponent<Props> = props => {
         {props.children}
       </Main>
       <ErrorBoundary>
-        <Footer
-          containerClassName={cx('Footer')}
-          buildNumber={buildNumber}
-          releaseDate={releaseDate}
-          displayName={displayName}
-        >
+        <Footer containerClassName={cx('Footer')}>
         </Footer>
       </ErrorBoundary>
       <ErrorBoundary>
@@ -85,14 +76,6 @@ function useIsHomePage() {
 
 function useDisplayName() {
   return useSelector((state: RootState) => state.globalData.config?.displayName);
-}
-
-function useBuildNumber() {
-  return useSelector((state: RootState) => state.globalData.config?.buildNumber);
-}
-
-function useReleaseDate() {
-  return useSelector((state: RootState) => state.globalData.config?.releaseDate);
 }
 
 function useHomePageTitle() {

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -1,8 +1,6 @@
-import React, { FunctionComponent, useEffect, useMemo } from 'react';
+import React, { FunctionComponent, useCallback, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router';
-
-import { noop } from 'lodash';
 
 import { Link } from 'wdk-client/Components';
 import { Props } from 'wdk-client/Components/Layout/Page';
@@ -15,6 +13,7 @@ import CookieBanner from 'ebrc-client/components/CookieBanner';
 import { Footer } from 'ebrc-client/components/homepage/Footer';
 import { Header } from 'ebrc-client/components/homepage/Header';
 import { Main } from 'ebrc-client/components/homepage/Main';
+import { useAnnouncementsState } from 'ebrc-client/hooks/announcements';
 
 import './OrthoMCLPage.scss';
 
@@ -28,7 +27,13 @@ export const OrthoMCLPage: FunctionComponent<Props> = props => {
   const releaseDate = useReleaseDate();
 
   const menuItems = useMemo(() => [], []);
-  const closedBanners = useMemo(() => [], []);
+
+  const {
+    closedBanners,
+    setClosedBanners,
+    showAnnouncementsToggle,
+    onShowAnnouncements
+  } = useAnnouncements();
 
   const branding = (
     <Link to="/">
@@ -43,15 +48,15 @@ export const OrthoMCLPage: FunctionComponent<Props> = props => {
         <Header
           menuItems={menuItems}
           containerClassName={cx('Header', 'expanded')}
-          onShowAnnouncements={noop}
-          showAnnouncementsToggle={false}
+          onShowAnnouncements={onShowAnnouncements}
+          showAnnouncementsToggle={showAnnouncementsToggle}
           branding={branding}
         />
       </ErrorBoundary>
       <div className={cx('Announcements')}>
         <Announcements
           closedBanners={closedBanners}
-          setClosedBanners={noop}
+          setClosedBanners={setClosedBanners}
         />
       </div>
       <Main containerClassName={cx('Main')}>
@@ -99,4 +104,29 @@ function useHomePageTitle() {
       document.title = displayName;
     }
   }, [ isHomePage, displayName ]);
+}
+
+function useAnnouncements() {
+  const isHomePage = useIsHomePage();
+  const [ closedBanners, setClosedBanners ] = useAnnouncementsState();
+
+  const showAnnouncementsToggle = useMemo(
+    () => isHomePage && closedBanners.length > 0,
+    [ isHomePage, closedBanners ]
+  );
+
+  const onShowAnnouncements = useCallback(() => {
+    setClosedBanners([]);
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  }, [ setClosedBanners ]);
+
+  return {
+    closedBanners,
+    setClosedBanners,
+    showAnnouncementsToggle,
+    onShowAnnouncements
+  };
 }

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -1,5 +1,6 @@
-import React, { FunctionComponent, useMemo } from 'react';
+import React, { FunctionComponent, useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { useLocation } from 'react-router';
 
 import { noop } from 'lodash';
 
@@ -20,9 +21,11 @@ import './OrthoMCLPage.scss';
 const cx = makeClassNameHelper('vpdb-');
 
 export const OrthoMCLPage: FunctionComponent<Props> = props => {
-  const buildNumber = useSelector((state: RootState) => state.globalData.config?.buildNumber);
-  const releaseDate = useSelector((state: RootState) => state.globalData.config?.releaseDate);
-  const displayName = useSelector((state: RootState) => state.globalData.config?.displayName);
+  useHomePageTitle();
+
+  const displayName = useDisplayName();
+  const buildNumber = useBuildNumber();
+  const releaseDate = useReleaseDate();
 
   const menuItems = useMemo(() => [], []);
   const closedBanners = useMemo(() => [], []);
@@ -68,4 +71,32 @@ export const OrthoMCLPage: FunctionComponent<Props> = props => {
       </ErrorBoundary>
     </div>
   );
+}
+
+function useIsHomePage() {
+  const location = useLocation();
+  return location.pathname === '/';
+}
+
+function useDisplayName() {
+  return useSelector((state: RootState) => state.globalData.config?.displayName);
+}
+
+function useBuildNumber() {
+  return useSelector((state: RootState) => state.globalData.config?.buildNumber);
+}
+
+function useReleaseDate() {
+  return useSelector((state: RootState) => state.globalData.config?.releaseDate);
+}
+
+function useHomePageTitle() {
+  const isHomePage = useIsHomePage();
+  const displayName = useDisplayName();
+
+  useEffect(() => {
+    if (isHomePage && displayName != null) {
+      document.title = displayName;
+    }
+  }, [ isHomePage, displayName ]);
 }

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
@@ -5,7 +5,7 @@ $dark-color: #414c9b;
 
 body.vpdb-Body .vpdb-RootContainer.vpdb-RootContainer__home-page {
   .vpdb-Main {
-    padding-right: 0;
+    padding: 0;
     margin: 0;
   }
 
@@ -13,15 +13,15 @@ body.vpdb-Body .vpdb-RootContainer.vpdb-RootContainer__home-page {
     display: grid;
 
     &__news-expanded {
-      grid-template-columns: 1fr 23em;
+      grid-template-columns: 26em 1fr 23em;
 
-      .vpdb-Bubbles {
-        border-right: 0.0625rem solid $dark-color;
+      .vpdb-MainContent {
+        border-right: 0.0625rem solid;
       }
     }
 
     &__news-collapsed {
-      grid-template-columns: 1fr 3em;
+      grid-template-columns: 31em 1fr 3em;
     }
 
     @media screen and (max-width: $tablet-width) {
@@ -30,57 +30,58 @@ body.vpdb-Body .vpdb-RootContainer.vpdb-RootContainer__home-page {
     }
   }
 
-  .vpdb-Bubbles {
-    display: flex;
-    justify-content: space-around;
-    flex-wrap: wrap;
-    align-content: flex-start;
-
-    font-size: 1.2em;
-
-    padding-top: 1.5em;
+  .vpdb-SearchPane {
+    min-height: 100vh;
   }
 
-  .vpdb-Bubble {
-    width: 20em;
-    margin: 0 1em 3em 1em;
-    border: 0.0625rem solid gray;
-    border-top-left-radius: 1.3em;
-    border-top-right-radius: 1.3em;
+  .vpdb-MainContent {
+    overflow: hidden;
+    border-left: 0.0625rem solid;
+    padding: 1.5em 1.25em 0 1.5em;
 
-    &Header {
-      text-align: center;
-      color: white;
-      background-color: $dark-color;
-      padding: 0.75em;
-      font-size: 1.2em;
-      border-top-left-radius: 1em;
-      border-top-right-radius: 1em;
+    > hr {
+      margin: 2em 0 0.75em 0;
     }
   }
 
-  .vpdb-Bubble.Groups .vpdb-BubbleHeader {
-    background-color: #3a486f;
-  }
+  .vpdb-FeaturedToolsListItem {
+    &__selected {
+      .vpdb-FeaturedToolsListItemIconContainer {
+        border-color: $dark-color;
+      }
+    }
 
-  .vpdb-Bubble.Sequences .vpdb-BubbleHeader {
-    background-color: #636a7e;
-  }
-
-  .vpdb-Bubble.Tools .vpdb-BubbleHeader {
-    background-color: #919191;
-  }
-
-  .vpdb-Bubble.Groups .vpdb-BubbleContent, .vpdb-Bubble.Sequences .vpdb-BubbleContent {
-    padding: 0.5em 0.5em 0.7em 0.5em;
-  }
-
-  .vpdb-Bubble.Tools .vpdb-BubbleContent {
-    padding: 0.75em;
+    &__selected:active, &__selected:hover, &__selected:link, &__selected:visited {
+      border-color: $dark-color;
+    }
   }
 
   .vpdb-NewsPane {
     grid-area: unset;
     border-style: none;
+  }
+
+  @media screen and (min-width: $hamburger-width + 1) {
+    .vpdb-NewsPane {
+      padding-bottom: 8em;
+    }
+
+    .vpdb-SearchPane, .vpdb-MainContent {
+      padding-bottom: 10em;
+    }
+
+    .vpdb-Footer {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+    }
+  }
+
+  .vpdb-BgDark {
+    background-color: $dark-color;
+  }
+
+  .vpdb-BdDark {
+    border-color: $dark-color;
   }
 }

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
@@ -31,6 +31,8 @@ $dark-color: #414c9b;
     flex-wrap: wrap;
     align-content: flex-start;
 
+    font-size: 1.2em;
+
     margin-top: 1.5em;
   }
 

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
@@ -67,7 +67,7 @@ $dark-color: #414c9b;
   }
 
   .vpdb-Bubble.Groups .vpdb-BubbleContent, .vpdb-Bubble.Sequences .vpdb-BubbleContent {
-    padding: 0 0.5em 0.7em 0.5em;
+    padding: 0.5em 0.5em 0.7em 0.5em;
   }
 
   .vpdb-Bubble.Tools .vpdb-BubbleContent {

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
@@ -1,0 +1,105 @@
+@import 'ebrc-client/styles/breakpoints.scss';
+
+$dark-color: #414c9b;
+
+.vpdb-RootContainer.vpdb-RootContainer__home-page main {
+  padding-right: 0;
+
+  .vpdb-LandingContent {
+    display: grid;
+
+    &__news-expanded {
+      grid-template-columns: 1fr 23em;
+    }
+
+    &__news-collapsed {
+      grid-template-columns: 1fr 3em;
+    }
+
+    @media screen and (max-width: $tablet-width) {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+
+  .vpdb-Bubbles {
+    display: flex;
+    justify-content: space-around;
+    flex-wrap: wrap;
+    align-content: flex-start;
+  }
+
+  .vpdb-Bubble {
+    width: 20em;
+    margin: 0 1em 3em 1em;
+    border: 0.0625rem solid gray;
+    border-top-left-radius: 1.3em;
+    border-top-right-radius: 1.3em;
+
+    &Header {
+      text-align: center;
+      color: white;
+      background-color: $dark-color;
+      padding: 0.75em;
+      font-size: 1.2em;
+      border-top-left-radius: 1em;
+      border-top-right-radius: 1em;
+    }
+  }
+
+  .vpdb-Bubble.Groups .vpdb-BubbleHeader {
+    background-color: #3a486f;
+  }
+
+  .vpdb-Bubble.Sequences .vpdb-BubbleHeader {
+    background-color: #636a7e;
+  }
+
+  .vpdb-Bubble.Tools .vpdb-BubbleHeader {
+    background-color: #919191;
+  }
+
+  .vpdb-Bubble.Groups .vpdb-BubbleContent, .vpdb-Bubble.Sequences .vpdb-BubbleContent {
+    padding: 0 0.5em 0.7em 0.5em;
+  }
+
+  .vpdb-Bubble.Tools .vpdb-BubbleContent {
+    padding: 0.75em;
+  }
+
+  .ebrc-NewsPane {
+    border-left: 0.0625rem solid $dark-color;
+
+    &__news-collapsed {
+      border-left-style: hidden;
+    }
+
+    .wdk-Showcase-HeadingRow {
+      display: none;
+    }
+
+    @media screen and (max-width: $tablet-width) {
+      border-left: none;
+
+      .wdk-Showcase-HeadingRow {
+        display: flex;
+      }
+    }
+  }
+
+  .wdk-Showcase {
+    margin: 0
+  }
+  .News-Section .News .NewsList {
+    max-height: 145px;
+    border-color: rgba(15,70,100,.12);
+    border-style: solid;
+    border-width: 1px 0;
+  }
+  .News-Section .News .NewsList .NewsTeaser{
+    display: none;
+  }
+  .News-Section .AllNewsLink {
+    font-size: 110%;
+  }
+}

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
@@ -1,8 +1,9 @@
 @import 'ebrc-client/styles/breakpoints.scss';
+@import 'ebrc-client/styles/news.scss';
 
 $dark-color: #414c9b;
 
-.vpdb-RootContainer.vpdb-RootContainer__home-page {
+body.vpdb-Body .vpdb-RootContainer.vpdb-RootContainer__home-page {
   .vpdb-Main {
     padding-right: 0;
     margin: 0;
@@ -13,6 +14,10 @@ $dark-color: #414c9b;
 
     &__news-expanded {
       grid-template-columns: 1fr 23em;
+
+      .vpdb-Bubbles {
+        border-right: 0.0625rem solid $dark-color;
+      }
     }
 
     &__news-collapsed {
@@ -33,7 +38,7 @@ $dark-color: #414c9b;
 
     font-size: 1.2em;
 
-    margin-top: 1.5em;
+    padding-top: 1.5em;
   }
 
   .vpdb-Bubble {
@@ -74,51 +79,8 @@ $dark-color: #414c9b;
     padding: 0.75em;
   }
 
-  .ebrc-NewsPane {
-    border-left: 0.0625rem solid $dark-color;
-
-    &__news-collapsed {
-      border-left-style: hidden;
-    }
-
-    .wdk-Showcase-HeadingRow {
-      display: none;
-    }
-
-    @media screen and (max-width: $tablet-width) {
-      border-left: none;
-
-      .wdk-Showcase-HeadingRow {
-        display: flex;
-      }
-    }
-  }
-
-  .wdk-Showcase {
-    margin: 0
-  }
-  .News-Section .News .NewsList {
-    max-height: 145px;
-    border-color: rgba(15,70,100,.12);
-    border-style: solid;
-    border-width: 1px 0;
-  }
-  .News-Section .News .NewsList .NewsTeaser{
-    display: none;
-  }
-  .News-Section .AllNewsLink {
-    font-size: 110%;
-  }
-
-  @media screen and (min-width: $hamburger-width + 1) {
-    .vpdb-Bubbles, .vpdb-NewsPane {
-      padding-bottom: 8em;
-    }
-
-    .vpdb-Footer {
-      position: fixed;
-      bottom: 0;
-      width: 100%;
-    }
+  .vpdb-NewsPane {
+    grid-area: unset;
+    border-style: none;
   }
 }

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
@@ -4,6 +4,7 @@ $dark-color: #414c9b;
 
 .vpdb-RootContainer.vpdb-RootContainer__home-page main {
   padding-right: 0;
+  margin: 0;
 
   .vpdb-LandingContent {
     display: grid;
@@ -27,6 +28,8 @@ $dark-color: #414c9b;
     justify-content: space-around;
     flex-wrap: wrap;
     align-content: flex-start;
+
+    margin-top: 1.5em;
   }
 
   .vpdb-Bubble {

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.scss
@@ -2,9 +2,11 @@
 
 $dark-color: #414c9b;
 
-.vpdb-RootContainer.vpdb-RootContainer__home-page main {
-  padding-right: 0;
-  margin: 0;
+.vpdb-RootContainer.vpdb-RootContainer__home-page {
+  .vpdb-Main {
+    padding-right: 0;
+    margin: 0;
+  }
 
   .vpdb-LandingContent {
     display: grid;
@@ -104,5 +106,17 @@ $dark-color: #414c9b;
   }
   .News-Section .AllNewsLink {
     font-size: 110%;
+  }
+
+  @media screen and (min-width: $hamburger-width + 1) {
+    .vpdb-Bubbles, .vpdb-NewsPane {
+      padding-bottom: 8em;
+    }
+
+    .vpdb-Footer {
+      position: fixed;
+      bottom: 0;
+      width: 100%;
+    }
   }
 }

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
@@ -1,7 +1,139 @@
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
+
+import { getLabel } from 'wdk-client/Utils/CategoryUtils';
+
+import { Link } from 'wdk-client/Components';
+import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
+
+import { useSearchTree, useSessionBackedSearchTerm, useSessionBackedExpandedBranches } from '../hooks/searchCheckboxTree';
+import { SearchCheckboxTree } from 'ebrc-client/components/homepage/SearchPane';
+import { NewsPane } from 'ebrc-client/components/homepage/NewsPane';
+import { STATIC_ROUTE_PATH } from 'ebrc-client/routes';
+import { useSessionBackedState } from 'wdk-client/Hooks/SessionBackedState';
+
+const IS_NEWS_EXPANDED_SESSION_KEY = 'homepage-is-news-expanded';
+
+const GROUP_RECORD_CLASS_FULL_NAME = 'GroupRecordClasses.GroupRecordClass';
+const GROUP_SEARCH_TERM_SESSION_KEY = 'homepage-group-search-term';
+const GROUP_EXPANDED_BRANCHES_SESSION_KEY = 'homepage-group-expanded-branch-ids';
+
+const SEQUENCE_RECORD_CLASS_FULL_NAME = 'SequenceRecordClasses.SequenceRecordClass';
+const SEQUENCE_SEARCH_TERM_SESSION_KEY = 'homepage-sequence-search-term';
+const SEQUENCE_EXPANDED_BRANCHES_SESSION_KEY = 'homepage-sequence-expanded-branch-ids';
 
 export function OrthoMCLHomePageController() {
+  const groupSearchTree = usePartialSearchTree(GROUP_RECORD_CLASS_FULL_NAME);
+  const [ groupSearchTerm, setGroupSearchTerm ] = useSessionBackedSearchTerm('', GROUP_SEARCH_TERM_SESSION_KEY);
+  const [ groupExpandedBranches, setGroupExpandedBranches ] = useSessionBackedExpandedBranches([], GROUP_EXPANDED_BRANCHES_SESSION_KEY);
+
+  const sequenceSearchTree = usePartialSearchTree(SEQUENCE_RECORD_CLASS_FULL_NAME);
+  const [ sequenceSearchTerm, setSequenceSearchTerm ] = useSessionBackedSearchTerm('', SEQUENCE_SEARCH_TERM_SESSION_KEY);
+  const [ sequenceExpandedBranches, setSequenceExpandedBranches ] = useSessionBackedExpandedBranches([], SEQUENCE_EXPANDED_BRANCHES_SESSION_KEY);
+
+  const [ isNewsExpanded, setIsNewsExpanded ] = useSessionBackedState(
+    false,
+    IS_NEWS_EXPANDED_SESSION_KEY,
+    encodeIsNewsExpanded,
+    parseIsNewsExpanded
+  );
+  const toggleNews = useCallback(
+    () => {
+      setIsNewsExpanded(!isNewsExpanded);
+    },
+    [ isNewsExpanded, setIsNewsExpanded ]
+  );
+
   return (
-    <div>Future OrthoMCL Home Page</div>
+    <React.Fragment>
+      <Bubble title="Identify Ortholog Groups">
+        <SearchCheckboxTree
+          searchTree={groupSearchTree}
+          searchTerm={groupSearchTerm}
+          expandedBranches={groupExpandedBranches}
+          setSearchTerm={setGroupSearchTerm}
+          setExpandedBranches={setGroupExpandedBranches}
+        />
+      </Bubble>
+      <Bubble title="Identify Protein Sequences">
+        <SearchCheckboxTree
+          searchTree={sequenceSearchTree}
+          searchTerm={sequenceSearchTerm}
+          expandedBranches={sequenceExpandedBranches}
+          setSearchTerm={setSequenceSearchTerm}
+          setExpandedBranches={setSequenceExpandedBranches}
+        />
+      </Bubble>
+      <Bubble title="Tools">
+        <ul>
+          <li>
+            <Link to="/search/sequence/ByBlast">
+              BLAST
+            </Link>
+          </li>
+          <li>
+            <Link to="/proteome-upload">
+              Assign your proteins to groups - TODO
+            </Link>
+          </li>
+          <li>
+            <Link to="/downloads">
+              Download OrthoMCL software
+            </Link>
+          </li>
+          <li>
+            <Link to={`${STATIC_ROUTE_PATH}/content/OrthoMCL/webServices.html`}>
+              Web services
+            </Link>
+          </li>
+          <li>
+            <a href="http://scholar.google.com/scholar?as_q=&num=10&as_epq=&as_oq=OrthoMCL&as_eq=encrypt+cryptography+hymenoptera&as_occt=any&as_sauthors=&as_publication=&as_ylo=&as_yhi=&as_sdt=1.&as_sdtp=on&as_sdtf=&as_sdts=39&btnG=Search+Scholar&hl=en" target="blank">
+              Publications mentioning OrthoMCL
+            </a>
+          </li>
+        </ul>
+      </Bubble>
+      <NewsPane
+        isNewsExpanded={isNewsExpanded}
+        toggleNews={toggleNews}
+      />
+    </React.Fragment>
+  );
+}
+
+const encodeIsNewsExpanded = (b: boolean) => b ? 'y' : '';
+const parseIsNewsExpanded = (s: string) => !!s;
+
+const bubbleCx = makeClassNameHelper('vpdb-Bubble');
+
+interface BubbleProps {
+  title?: React.ReactNode,
+  containerClassName?: string
+}
+
+const Bubble: React.FunctionComponent<BubbleProps> = props => {
+  const className = props.containerClassName == null
+    ? bubbleCx()
+    : `${bubbleCx()} ${props.containerClassName}`;
+
+  return (
+    <div className={className}>
+      <div className={bubbleCx('Header')}>
+        {props.title}
+      </div>
+      <div className={bubbleCx('Content')}>
+        {props.children}
+      </div>
+    </div>
+  );
+}
+
+function usePartialSearchTree(recordClassName: string) {
+  const fullSearchTree = useSearchTree();
+
+  return useMemo(
+    () => fullSearchTree == null
+      ? undefined
+      : fullSearchTree?.children.find(node => getLabel(node) === recordClassName),
+    [ fullSearchTree ]
   );
 }

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
@@ -32,12 +32,6 @@ export function OrthoMCLHomePageController() {
     [ isNewsExpanded, setIsNewsExpanded ]
   );
 
-  useLayoutEffect(() => {
-    // FIXME: This is a hack for recalculating the "rabbit ears"
-    // of Featured Tools whenever the news is expanded/collapsed
-    window.dispatchEvent(new Event('resize'));
-  }, [ isNewsExpanded ]);
-
   return (
     <div className={cx('LandingContent', isNewsExpanded ? 'news-expanded' : 'news-collapsed')}>
       <SearchPane

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
@@ -1,40 +1,23 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useLayoutEffect } from 'react';
 
-import { getLabel } from 'wdk-client/Utils/CategoryUtils';
-
-import { Link } from 'wdk-client/Components';
-import { LinksPosition } from 'wdk-client/Components/CheckboxTree/CheckboxTree';
 import { useSessionBackedState } from 'wdk-client/Hooks/SessionBackedState';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
 
-import { useSearchTree, useSessionBackedSearchTerm, useSessionBackedExpandedBranches } from '../hooks/searchCheckboxTree';
-import { SearchCheckboxTree } from 'ebrc-client/components/homepage/SearchPane';
+import { FeaturedTools } from 'ebrc-client/components/homepage/FeaturedTools';
+import { SearchPane } from 'ebrc-client/components/homepage/SearchPane';
+import { WorkshopExercises } from 'ebrc-client/components/homepage/WorkshopExercises';
 import { NewsPane } from 'ebrc-client/components/homepage/NewsPane';
-import { STATIC_ROUTE_PATH } from 'ebrc-client/routes';
+
+import { useSearchTree } from '../hooks/searchCheckboxTree';
 
 const IS_NEWS_EXPANDED_SESSION_KEY = 'homepage-is-news-expanded';
-
-const GROUP_RECORD_CLASS_FULL_NAME = 'GroupRecordClasses.GroupRecordClass';
-const GROUP_SEARCH_TERM_SESSION_KEY = 'homepage-group-search-term';
-const GROUP_EXPANDED_BRANCHES_SESSION_KEY = 'homepage-group-expanded-branch-ids';
-
-const SEQUENCE_RECORD_CLASS_FULL_NAME = 'SequenceRecordClasses.SequenceRecordClass';
-const SEQUENCE_SEARCH_TERM_SESSION_KEY = 'homepage-sequence-search-term';
-const SEQUENCE_EXPANDED_BRANCHES_SESSION_KEY = 'homepage-sequence-expanded-branch-ids';
 
 const cx = makeClassNameHelper('vpdb-');
 
 import './OrthoMCLHomePageController.scss';
 
-
 export function OrthoMCLHomePageController() {
-  const groupSearchTree = usePartialSearchTree(GROUP_RECORD_CLASS_FULL_NAME);
-  const [ groupSearchTerm, setGroupSearchTerm ] = useSessionBackedSearchTerm('', GROUP_SEARCH_TERM_SESSION_KEY);
-  const [ groupExpandedBranches, setGroupExpandedBranches ] = useSessionBackedExpandedBranches([], GROUP_EXPANDED_BRANCHES_SESSION_KEY);
-
-  const sequenceSearchTree = usePartialSearchTree(SEQUENCE_RECORD_CLASS_FULL_NAME);
-  const [ sequenceSearchTerm, setSequenceSearchTerm ] = useSessionBackedSearchTerm('', SEQUENCE_SEARCH_TERM_SESSION_KEY);
-  const [ sequenceExpandedBranches, setSequenceExpandedBranches ] = useSessionBackedExpandedBranches([], SEQUENCE_EXPANDED_BRANCHES_SESSION_KEY);
+  const searchTree = useSearchTree();
 
   const [ isNewsExpanded, setIsNewsExpanded ] = useSessionBackedState(
     false,
@@ -49,58 +32,22 @@ export function OrthoMCLHomePageController() {
     [ isNewsExpanded, setIsNewsExpanded ]
   );
 
+  useLayoutEffect(() => {
+    // FIXME: This is a hack for recalculating the "rabbit ears"
+    // of Featured Tools whenever the news is expanded/collapsed
+    window.dispatchEvent(new Event('resize'));
+  }, [ isNewsExpanded ]);
+
   return (
     <div className={cx('LandingContent', isNewsExpanded ? 'news-expanded' : 'news-collapsed')}>
-      <div className={cx('Bubbles')}>
-        <Bubble title="Identify Ortholog Groups" containerClassName="Groups">
-          <SearchCheckboxTree
-            searchTree={groupSearchTree}
-            searchTerm={groupSearchTerm}
-            expandedBranches={groupExpandedBranches}
-            setSearchTerm={setGroupSearchTerm}
-            setExpandedBranches={setGroupExpandedBranches}
-            linksPosition={LinksPosition.None}
-          />
-        </Bubble>
-        <Bubble title="Identify Protein Sequences" containerClassName="Sequences">
-          <SearchCheckboxTree
-            searchTree={sequenceSearchTree}
-            searchTerm={sequenceSearchTerm}
-            expandedBranches={sequenceExpandedBranches}
-            setSearchTerm={setSequenceSearchTerm}
-            setExpandedBranches={setSequenceExpandedBranches}
-            linksPosition={LinksPosition.None}
-          />
-        </Bubble>
-        <Bubble title="Tools" containerClassName="Tools">
-          <ul>
-            <li>
-              <Link to="/search/sequence/ByBlast">
-                BLAST
-              </Link>
-            </li>
-            <li>
-              <Link to="/proteome-upload">
-                Assign your proteins to groups - TODO
-              </Link>
-            </li>
-            <li>
-              <Link to="/downloads">
-                Download OrthoMCL software
-              </Link>
-            </li>
-            <li>
-              <Link to={`${STATIC_ROUTE_PATH}/content/OrthoMCL/webServices.html`}>
-                Web services
-              </Link>
-            </li>
-            <li>
-              <a href="http://scholar.google.com/scholar?as_q=&num=10&as_epq=&as_oq=OrthoMCL&as_eq=encrypt+cryptography+hymenoptera&as_occt=any&as_sauthors=&as_publication=&as_ylo=&as_yhi=&as_sdt=1.&as_sdtp=on&as_sdtf=&as_sdts=39&btnG=Search+Scholar&hl=en" target="blank">
-                Publications mentioning OrthoMCL
-              </a>
-            </li>
-          </ul>
-        </Bubble>
+      <SearchPane
+        containerClassName={`${cx('SearchPane')} ${cx('BgWash')}`}
+        searchTree={searchTree}
+      />
+      <div className={cx('MainContent')}>
+        <FeaturedTools />
+        <hr />
+        <WorkshopExercises />
       </div>
       <NewsPane
         containerClassName={cx('NewsPane', isNewsExpanded ? 'news-expanded' : 'news-collapsed')}
@@ -113,38 +60,3 @@ export function OrthoMCLHomePageController() {
 
 const encodeIsNewsExpanded = (b: boolean) => b ? 'y' : '';
 const parseIsNewsExpanded = (s: string) => !!s;
-
-const bubbleCx = makeClassNameHelper('vpdb-Bubble');
-
-interface BubbleProps {
-  title?: React.ReactNode,
-  containerClassName?: string
-}
-
-const Bubble: React.FunctionComponent<BubbleProps> = props => {
-  const className = props.containerClassName == null
-    ? bubbleCx()
-    : `${bubbleCx()} ${props.containerClassName}`;
-
-  return (
-    <div className={className}>
-      <div className={bubbleCx('Header')}>
-        {props.title}
-      </div>
-      <div className={bubbleCx('Content')}>
-        {props.children}
-      </div>
-    </div>
-  );
-}
-
-function usePartialSearchTree(recordClassName: string) {
-  const fullSearchTree = useSearchTree();
-
-  return useMemo(
-    () => fullSearchTree == null
-      ? undefined
-      : fullSearchTree?.children.find(node => getLabel(node) === recordClassName),
-    [ fullSearchTree ]
-  );
-}

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
@@ -21,6 +21,10 @@ const SEQUENCE_RECORD_CLASS_FULL_NAME = 'SequenceRecordClasses.SequenceRecordCla
 const SEQUENCE_SEARCH_TERM_SESSION_KEY = 'homepage-sequence-search-term';
 const SEQUENCE_EXPANDED_BRANCHES_SESSION_KEY = 'homepage-sequence-expanded-branch-ids';
 
+const cx = makeClassNameHelper('vpdb-');
+
+import './OrthoMCLHomePageController.scss';
+
 export function OrthoMCLHomePageController() {
   const groupSearchTree = usePartialSearchTree(GROUP_RECORD_CLASS_FULL_NAME);
   const [ groupSearchTerm, setGroupSearchTerm ] = useSessionBackedSearchTerm('', GROUP_SEARCH_TERM_SESSION_KEY);
@@ -44,59 +48,62 @@ export function OrthoMCLHomePageController() {
   );
 
   return (
-    <React.Fragment>
-      <Bubble title="Identify Ortholog Groups">
-        <SearchCheckboxTree
-          searchTree={groupSearchTree}
-          searchTerm={groupSearchTerm}
-          expandedBranches={groupExpandedBranches}
-          setSearchTerm={setGroupSearchTerm}
-          setExpandedBranches={setGroupExpandedBranches}
-        />
-      </Bubble>
-      <Bubble title="Identify Protein Sequences">
-        <SearchCheckboxTree
-          searchTree={sequenceSearchTree}
-          searchTerm={sequenceSearchTerm}
-          expandedBranches={sequenceExpandedBranches}
-          setSearchTerm={setSequenceSearchTerm}
-          setExpandedBranches={setSequenceExpandedBranches}
-        />
-      </Bubble>
-      <Bubble title="Tools">
-        <ul>
-          <li>
-            <Link to="/search/sequence/ByBlast">
-              BLAST
-            </Link>
-          </li>
-          <li>
-            <Link to="/proteome-upload">
-              Assign your proteins to groups - TODO
-            </Link>
-          </li>
-          <li>
-            <Link to="/downloads">
-              Download OrthoMCL software
-            </Link>
-          </li>
-          <li>
-            <Link to={`${STATIC_ROUTE_PATH}/content/OrthoMCL/webServices.html`}>
-              Web services
-            </Link>
-          </li>
-          <li>
-            <a href="http://scholar.google.com/scholar?as_q=&num=10&as_epq=&as_oq=OrthoMCL&as_eq=encrypt+cryptography+hymenoptera&as_occt=any&as_sauthors=&as_publication=&as_ylo=&as_yhi=&as_sdt=1.&as_sdtp=on&as_sdtf=&as_sdts=39&btnG=Search+Scholar&hl=en" target="blank">
-              Publications mentioning OrthoMCL
-            </a>
-          </li>
-        </ul>
-      </Bubble>
+    <div className={cx('LandingContent', isNewsExpanded ? 'news-expanded' : 'news-collapsed')}>
+      <div className={cx('Bubbles')}>
+        <Bubble title="Identify Ortholog Groups" containerClassName="Groups">
+          <SearchCheckboxTree
+            searchTree={groupSearchTree}
+            searchTerm={groupSearchTerm}
+            expandedBranches={groupExpandedBranches}
+            setSearchTerm={setGroupSearchTerm}
+            setExpandedBranches={setGroupExpandedBranches}
+          />
+        </Bubble>
+        <Bubble title="Identify Protein Sequences" containerClassName="Sequences">
+          <SearchCheckboxTree
+            searchTree={sequenceSearchTree}
+            searchTerm={sequenceSearchTerm}
+            expandedBranches={sequenceExpandedBranches}
+            setSearchTerm={setSequenceSearchTerm}
+            setExpandedBranches={setSequenceExpandedBranches}
+          />
+        </Bubble>
+        <Bubble title="Tools" containerClassName="Tools">
+          <ul>
+            <li>
+              <Link to="/search/sequence/ByBlast">
+                BLAST
+              </Link>
+            </li>
+            <li>
+              <Link to="/proteome-upload">
+                Assign your proteins to groups - TODO
+              </Link>
+            </li>
+            <li>
+              <Link to="/downloads">
+                Download OrthoMCL software
+              </Link>
+            </li>
+            <li>
+              <Link to={`${STATIC_ROUTE_PATH}/content/OrthoMCL/webServices.html`}>
+                Web services
+              </Link>
+            </li>
+            <li>
+              <a href="http://scholar.google.com/scholar?as_q=&num=10&as_epq=&as_oq=OrthoMCL&as_eq=encrypt+cryptography+hymenoptera&as_occt=any&as_sauthors=&as_publication=&as_ylo=&as_yhi=&as_sdt=1.&as_sdtp=on&as_sdtf=&as_sdts=39&btnG=Search+Scholar&hl=en" target="blank">
+                Publications mentioning OrthoMCL
+              </a>
+            </li>
+          </ul>
+        </Bubble>
+      </div>
       <NewsPane
+        containerClassName={cx('NewsPane')}
         isNewsExpanded={isNewsExpanded}
         toggleNews={toggleNews}
       />
-    </React.Fragment>
+    </div>
   );
 }
 

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export function OrthoMCLHomePageController() {
+  return (
+    <div>Future OrthoMCL Home Page</div>
+  );
+}

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
@@ -103,7 +103,7 @@ export function OrthoMCLHomePageController() {
         </Bubble>
       </div>
       <NewsPane
-        containerClassName={cx('NewsPane')}
+        containerClassName={cx('NewsPane', isNewsExpanded ? 'news-expanded' : 'news-collapsed')}
         isNewsExpanded={isNewsExpanded}
         toggleNews={toggleNews}
       />

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
@@ -3,13 +3,14 @@ import React, { useCallback, useMemo } from 'react';
 import { getLabel } from 'wdk-client/Utils/CategoryUtils';
 
 import { Link } from 'wdk-client/Components';
+import { LinksPosition } from 'wdk-client/Components/CheckboxTree/CheckboxTree';
+import { useSessionBackedState } from 'wdk-client/Hooks/SessionBackedState';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
 
 import { useSearchTree, useSessionBackedSearchTerm, useSessionBackedExpandedBranches } from '../hooks/searchCheckboxTree';
 import { SearchCheckboxTree } from 'ebrc-client/components/homepage/SearchPane';
 import { NewsPane } from 'ebrc-client/components/homepage/NewsPane';
 import { STATIC_ROUTE_PATH } from 'ebrc-client/routes';
-import { useSessionBackedState } from 'wdk-client/Hooks/SessionBackedState';
 
 const IS_NEWS_EXPANDED_SESSION_KEY = 'homepage-is-news-expanded';
 
@@ -24,6 +25,7 @@ const SEQUENCE_EXPANDED_BRANCHES_SESSION_KEY = 'homepage-sequence-expanded-branc
 const cx = makeClassNameHelper('vpdb-');
 
 import './OrthoMCLHomePageController.scss';
+
 
 export function OrthoMCLHomePageController() {
   const groupSearchTree = usePartialSearchTree(GROUP_RECORD_CLASS_FULL_NAME);
@@ -57,6 +59,7 @@ export function OrthoMCLHomePageController() {
             expandedBranches={groupExpandedBranches}
             setSearchTerm={setGroupSearchTerm}
             setExpandedBranches={setGroupExpandedBranches}
+            linksPosition={LinksPosition.None}
           />
         </Bubble>
         <Bubble title="Identify Protein Sequences" containerClassName="Sequences">
@@ -66,6 +69,7 @@ export function OrthoMCLHomePageController() {
             expandedBranches={sequenceExpandedBranches}
             setSearchTerm={setSequenceSearchTerm}
             setExpandedBranches={setSequenceExpandedBranches}
+            linksPosition={LinksPosition.None}
           />
         </Bubble>
         <Bubble title="Tools" containerClassName="Tools">

--- a/Site/webapp/wdkCustomization/js/client/hooks/searchCheckboxTree.ts
+++ b/Site/webapp/wdkCustomization/js/client/hooks/searchCheckboxTree.ts
@@ -9,7 +9,7 @@ import { decode, arrayOf, string } from 'wdk-client/Utils/Json';
 
 export function useSearchTree() {
   return useSelector(
-    (state: RootState) => get(state.globalData, 'searchTree') as CategoryTreeNode
+    (state: RootState) => get(state.globalData, 'searchTree') as CategoryTreeNode | undefined
   );
 }
 

--- a/Site/webapp/wdkCustomization/js/client/hooks/searchCheckboxTree.ts
+++ b/Site/webapp/wdkCustomization/js/client/hooks/searchCheckboxTree.ts
@@ -1,0 +1,41 @@
+import { useSelector } from 'react-redux';
+
+import { get, memoize } from 'lodash';
+
+import { RootState } from 'wdk-client/Core/State/Types';
+import { useSessionBackedState } from 'wdk-client/Hooks/SessionBackedState';
+import { CategoryTreeNode } from 'wdk-client/Utils/CategoryUtils';
+import { decode, arrayOf, string } from 'wdk-client/Utils/Json';
+
+export function useSearchTree() {
+  return useSelector(
+    (state: RootState) => get(state.globalData, 'searchTree') as CategoryTreeNode
+  );
+}
+
+export function useSessionBackedSearchTerm(initialSearchTerm: string, key: string) {
+  return useSessionBackedState(
+    initialSearchTerm,
+    key,
+    encodeSearchTerm,
+    parseSearchTerm
+  );
+}
+
+export function useSessionBackedExpandedBranches(initialExpandedBranches: string[], key: string) {
+  return useSessionBackedState(
+    initialExpandedBranches,
+    key,
+    encodeExpandedBranches,
+    parseExpandedBranches
+  );
+}
+
+const encodeSearchTerm = (s: string) => s;
+const parseSearchTerm = encodeSearchTerm;
+
+const encodeExpandedBranches = JSON.stringify;
+const parseExpandedBranches = memoize((s: string) => decode(
+  arrayOf(string),
+  s
+));

--- a/Site/webapp/wdkCustomization/js/client/main.js
+++ b/Site/webapp/wdkCustomization/js/client/main.js
@@ -1,8 +1,10 @@
 import { initialize } from 'ebrc-client/bootstrap';
 import componentWrappers from './component-wrappers';
+import { wrapRoutes } from './routes';
 
 import 'eupathdb/wdkCustomization/css/client.scss';
 
 initialize({
-  componentWrappers
+  componentWrappers,
+  wrapRoutes
 });

--- a/Site/webapp/wdkCustomization/js/client/routes.tsx
+++ b/Site/webapp/wdkCustomization/js/client/routes.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
-import { RouteEntry } from "wdk-client/Core/RouteEntry";
+import { RouteEntry } from 'wdk-client/Core/RouteEntry';
+
+import { OrthoMCLHomePageController } from './controllers/OrthoMCLHomePageController';
 
 export function wrapRoutes(ebrcRoutes: RouteEntry[]): RouteEntry[] {
   return [
     {
       path: '/',
-      component: () => <div>Future OrthoMCL Home Page</div>
+      component: OrthoMCLHomePageController
     },
     ...ebrcRoutes
   ];

--- a/Site/webapp/wdkCustomization/js/client/routes.tsx
+++ b/Site/webapp/wdkCustomization/js/client/routes.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { RouteEntry } from "wdk-client/Core/RouteEntry";
+
+export function wrapRoutes(ebrcRoutes: RouteEntry[]): RouteEntry[] {
+  return [
+    {
+      path: '/',
+      component: () => <div>Future OrthoMCL Home Page</div>
+    },
+    ...ebrcRoutes
+  ];
+}

--- a/Site/webapp/wdkCustomization/js/client/routes.tsx
+++ b/Site/webapp/wdkCustomization/js/client/routes.tsx
@@ -6,7 +6,8 @@ export function wrapRoutes(ebrcRoutes: RouteEntry[]): RouteEntry[] {
   return [
     {
       path: '/',
-      component: OrthoMCLHomePageController
+      component: OrthoMCLHomePageController,
+      rootClassNameModifier: 'home-page'
     },
     ...ebrcRoutes
   ];


### PR DESCRIPTION
This PR provides a first implementation of the OrthoMCL home page + page layout.

Note: there are some lingering. content todos, specifically regarding...

* "About" and "Help" Submenu content (to be discussed with outreach)
* OrthoMCL-specific "Overview of Resources & Tools" and "News" (to be implemented in Jekyll)
* Categories for the OrthoMCL search checkbox tree (to be handled with an ontology update)

This PR depends on...

* https://github.com/VEuPathDB/WDKClient/pull/16
* https://github.com/VEuPathDB/EbrcWebsiteCommon/pull/3