### PR TITLE
Some custom attributes/tables for record pages

### DIFF
--- a/Site/webapp/wdkCustomization/css/client.scss
+++ b/Site/webapp/wdkCustomization/css/client.scss
@@ -1,0 +1,5 @@
+.wdk-DataTableCell__legend {
+  .PfamDomain {
+    width: 16.6666666667em;
+  }
+}

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers.ts
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers.ts
@@ -1,5 +1,0 @@
-import { OrthoMCLPage } from './components/layout/OrthoMCLPage';
-
-export default {
-  Page: () => OrthoMCLPage
-};

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
@@ -6,6 +6,9 @@ import {
   RecordAttributeSection as GroupRecordAttributeSection
 } from './records/GroupRecordClasses.GroupRecordClass';
 import {
+  RecordTable as SequenceRecordTable
+} from './records/SequenceRecordClasses.SequenceRecordClass';
+import {
   RecordAttributeSectionProps,
   RecordTableProps
 } from './records/Types';
@@ -24,7 +27,9 @@ const wrappedComponentsByRecordClass: Record<string, Record<string, React.Compon
     RecordAttributeSection: GroupRecordAttributeSection,
     RecordTable: GroupRecordTable
   },
-  [SEQUENCE_RECORD_CLASS_NAME]: {}
+  [SEQUENCE_RECORD_CLASS_NAME]: {
+    RecordTable: SequenceRecordTable
+  }
 };
 
 function makeDynamicWrapper<P>(componentName: string, getWrapperType: (props: P) => string) {

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 
 import { OrthoMCLPage } from './components/layout/OrthoMCLPage';
 import {
-  RecordAttributeSectionProps,
-  RecordTableProps,
   RecordTable as GroupRecordTable,
-  RecordAttributeSection as GroupRecordAttributeSection,
+  RecordAttributeSection as GroupRecordAttributeSection
 } from './records/GroupRecordClasses.GroupRecordClass';
+import {
+  RecordAttributeSectionProps,
+  RecordTableProps
+} from './records/Types';
 
 export default {
   Page: () => OrthoMCLPage,

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { OrthoMCLPage } from './components/layout/OrthoMCLPage';
+import {
+  RecordAttributeSection as GroupRecordAttributeSection,
+  RecordAttributeSectionProps
+} from './records/GroupRecordClasses.GroupRecordClass';
+
+export default {
+  Page: () => OrthoMCLPage,
+  RecordAttributeSection: makeDynamicWrapper('RecordAttributeSection', (props: RecordAttributeSectionProps) => props.recordClass.fullName)
+};
+
+const GROUP_RECORD_CLASS_NAME = 'GroupRecordClasses.GroupRecordClass';
+const SEQUENCE_RECORD_CLASS_NAME = 'SequenceRecordClasses.SequenceRecordClass';
+
+const wrappedComponentsByRecordClass: Record<string, Record<string, React.ComponentType<any>>> = {
+  [GROUP_RECORD_CLASS_NAME]: {
+    RecordAttributeSection: GroupRecordAttributeSection
+  },
+  [SEQUENCE_RECORD_CLASS_NAME]: {}
+};
+
+function makeDynamicWrapper<P>(componentName: string, getWrapperType: (props: P) => string) {
+  return function dynamicWrapper(DefaultComponent: React.ComponentType<P>) {
+    return function WrappedComponent(props: P) {
+      const wrapperType = getWrapperType(props);
+      const availableWrappers = wrappedComponentsByRecordClass[wrapperType] || {};
+      const ResolvedComponent = availableWrappers[componentName] || DefaultComponent;
+
+      return <ResolvedComponent {...props} DefaultComponent={DefaultComponent} />;
+    };
+  };
+}

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 
 import { OrthoMCLPage } from './components/layout/OrthoMCLPage';
 import {
+  RecordAttributeSectionProps,
+  RecordTableProps,
+  RecordTable as GroupRecordTable,
   RecordAttributeSection as GroupRecordAttributeSection,
-  RecordAttributeSectionProps
 } from './records/GroupRecordClasses.GroupRecordClass';
 
 export default {
   Page: () => OrthoMCLPage,
-  RecordAttributeSection: makeDynamicWrapper('RecordAttributeSection', (props: RecordAttributeSectionProps) => props.recordClass.fullName)
+  RecordAttributeSection: makeDynamicWrapper('RecordAttributeSection', (props: RecordAttributeSectionProps) => props.recordClass.fullName),
+  RecordTable: makeDynamicWrapper('RecordTable', (props: RecordTableProps) => props.recordClass.fullName)
 };
 
 const GROUP_RECORD_CLASS_NAME = 'GroupRecordClasses.GroupRecordClass';
@@ -16,7 +19,8 @@ const SEQUENCE_RECORD_CLASS_NAME = 'SequenceRecordClasses.SequenceRecordClass';
 
 const wrappedComponentsByRecordClass: Record<string, Record<string, React.ComponentType<any>>> = {
   [GROUP_RECORD_CLASS_NAME]: {
-    RecordAttributeSection: GroupRecordAttributeSection
+    RecordAttributeSection: GroupRecordAttributeSection,
+    RecordTable: GroupRecordTable
   },
   [SEQUENCE_RECORD_CLASS_NAME]: {}
 };

--- a/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomain.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomain.scss
@@ -1,4 +1,7 @@
 .PfamDomain {
+  border: 0.0625rem solid #eee;
+  border-radius: 0.41666666666em;
+
   .Band {
     height: 0.41666666666em;
   }

--- a/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomain.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomain.scss
@@ -1,0 +1,15 @@
+.PfamDomain {
+  .Band {
+    height: 0.41666666666em;
+  }
+
+  .Band:first-child {
+    border-top-left-radius: 0.41666666666em;
+    border-top-right-radius: 0.41666666666em;
+  }
+
+  .Band:last-child {
+    border-bottom-left-radius: 0.41666666666em;
+    border-bottom-right-radius: 0.41666666666em;
+  }
+}

--- a/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomain.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomain.tsx
@@ -17,7 +17,7 @@ export function PfamDomain({ pfamId, style, title }: Props) {
     <div className="PfamDomain" style={style} title={title}>
       {
         colors.map(
-          (color, i) => <div className="Band" key={i} style={{ backgroundColor: color }} ></div>
+          (color, i) => <div className="Band" key={i} style={{ backgroundColor: color }}></div>
         )
       }
     </div>

--- a/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomain.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomain.tsx
@@ -1,0 +1,25 @@
+import React, { useMemo } from 'react';
+
+import { assignColors } from '../../utils/pfamDomain';
+
+import './PfamDomain.scss';
+
+interface Props {
+  pfamId: string,
+  style?: React.CSSProperties,
+  title?: string
+}
+
+export function PfamDomain({ pfamId, style, title }: Props) {
+  const colors = useMemo(() => assignColors(pfamId), [ pfamId ]);
+
+  return (
+    <div className="PfamDomain" style={style} title={title}>
+      {
+        colors.map(
+          (color, i) => <div className="Band" key={i} style={{ backgroundColor: color }} ></div>
+        )
+      }
+    </div>
+  );
+}

--- a/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomain.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomain.tsx
@@ -5,9 +5,9 @@ import { assignColors } from '../../utils/pfamDomain';
 import './PfamDomain.scss';
 
 interface Props {
-  pfamId: string,
-  style?: React.CSSProperties,
-  title?: string
+  pfamId: string;
+  style?: React.CSSProperties;
+  title?: string;
 }
 
 export function PfamDomain({ pfamId, style, title }: Props) {

--- a/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomainArchitecture.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomainArchitecture.scss
@@ -1,0 +1,15 @@
+.PfamDomainArchitecture {
+  position: relative;
+  display: flex;
+  align-items: center;
+
+  .ProteinGraph {
+    background-color: #666;
+    height: 0.0625rem;
+    width: 100%;
+  }
+
+  .PfamDomain {
+    position: absolute;
+  }
+}

--- a/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomainArchitecture.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomainArchitecture.tsx
@@ -7,17 +7,18 @@ import './PfamDomainArchitecture.scss';
 interface Props {
   length: number;
   domains: { start: number, end: number, pfamId: string }[];
+  style: React.CSSProperties;
 }
 
-interface Domain {
+export interface Domain {
   start: number;
   end: number;
   pfamId: string;
 };
 
-export function PfamDomainArchitecture({ length, domains }: Props) {
+export function PfamDomainArchitecture({ length, domains, style }: Props) {
   return (
-    <div className="PfamDomainArchitecture">
+    <div className="PfamDomainArchitecture" style={style}>
       <div className="ProteinGraph"></div>
       {
         domains.map(

--- a/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomainArchitecture.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomainArchitecture.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { PfamDomain } from './PfamDomain';
+
+import './PfamDomainArchitecture.scss';
+
+interface Props {
+  length: number;
+  domains: { start: number, end: number, pfamId: string }[];
+}
+
+interface Domain {
+  start: number;
+  end: number;
+  pfamId: string;
+};
+
+export function PfamDomainArchitecture({ length, domains }: Props) {
+  return (
+    <div className="PfamDomainArchitecture">
+      <div className="ProteinGraph"></div>
+      {
+        domains.map(
+          domain => (
+            <PfamDomain
+              key={domain.pfamId}
+              pfamId={domain.pfamId}
+              title={makeDomainTitle(domain)}
+              style={makeDomainPositionStyling(length, domain)}
+            />
+          )
+        )
+      }
+    </div>
+  );
+}
+
+function makeDomainTitle({ start, end, pfamId }: Domain) {
+  return `${pfamId} (location: [${start} - ${end}])`;
+}
+
+function makeDomainPositionStyling(architectureLength: number, { start, end }: Domain): React.CSSProperties {
+  const domainLength = end - start + 1;
+
+  const domainWidth = `${(domainLength / architectureLength) * 100}%`;
+  const domainLeft = `${(start / architectureLength) * 100}%`;
+
+  return {
+    width: domainWidth,
+    left: domainLeft
+  };
+}

--- a/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomainArchitecture.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomainArchitecture.tsx
@@ -7,7 +7,7 @@ import './PfamDomainArchitecture.scss';
 interface Props {
   length: number;
   domains: { start: number, end: number, pfamId: string }[];
-  style: React.CSSProperties;
+  style?: React.CSSProperties;
 }
 
 export interface Domain {
@@ -24,7 +24,7 @@ export function PfamDomainArchitecture({ length, domains, style }: Props) {
         domains.map(
           domain => (
             <PfamDomain
-              key={domain.pfamId}
+              key={`${domain.pfamId}}-${domain.start}-${domain.start}`}
               pfamId={domain.pfamId}
               title={makeDomainTitle(domain)}
               style={makeDomainPositionStyling(length, domain)}

--- a/Site/webapp/wdkCustomization/js/client/main.js
+++ b/Site/webapp/wdkCustomization/js/client/main.js
@@ -3,6 +3,7 @@ import componentWrappers from './component-wrappers';
 import { wrapRoutes } from './routes';
 
 import 'eupathdb/wdkCustomization/css/client.scss';
+import '../../css/client.scss';
 
 initialize({
   componentWrappers,

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.scss
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.scss
@@ -2,4 +2,10 @@
   .wdk-MissingMsaAttribute {
     color: darkred;
   }
+
+  .wdk-DataTableCell__legend {
+    .PfamDomain {
+      width: 16.6666666667em;
+    }
+  }
 }

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.scss
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.scss
@@ -8,4 +8,18 @@
       width: 16.6666666667em;
     }
   }
+
+  th.wdk-DataTableCell__domains {
+    width: 35em;
+  }
+
+  td.wdk-DataTableCell__domains {
+    vertical-align: middle;
+    padding-top: 1.2em;
+    padding-bottom: 1.2em;
+
+    .PfamDomain {
+      min-width: 0.41666666666em;
+    }
+  }
 }

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.scss
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.scss
@@ -3,12 +3,6 @@
     color: darkred;
   }
 
-  .wdk-DataTableCell__legend {
-    .PfamDomain {
-      width: 16.6666666667em;
-    }
-  }
-
   th.wdk-DataTableCell__domains {
     width: 35em;
   }

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.scss
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.scss
@@ -1,0 +1,5 @@
+.wdk-RecordContainer__GroupRecordClasses\.GroupRecordClass {
+  .wdk-MissingMsaAttribute {
+    color: darkred;
+  }
+}

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
@@ -1,14 +1,19 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 import { requestPartialRecord } from 'wdk-client/Actions/RecordActions';
 import { CollapsibleSection } from 'wdk-client/Components';
 import { CategoryTreeNode } from 'wdk-client/Utils/CategoryUtils';
-import { RecordClass, RecordInstance, Reporter } from 'wdk-client/Utils/WdkModel';
+import { AttributeField, AttributeValue, RecordClass, RecordInstance, TableField, TableValue } from 'wdk-client/Utils/WdkModel';
+
+import { PfamDomain } from '../components/pfam-domains/PfamDomain';
 
 import './GroupRecordClasses.GroupRecordClass.scss';
 
+type WrappedComponentProps<T> = T & { DefaultComponent: React.ComponentType<T> };
+
 export interface RecordAttributeSectionProps {
-  attribute: Reporter;
+  attribute: AttributeField;
   isCollapsed: boolean;
   onCollapsedChange: () => void;
   ontologyProperties: CategoryTreeNode['properties'];
@@ -17,8 +22,22 @@ export interface RecordAttributeSectionProps {
   requestPartialRecord: typeof requestPartialRecord;
 }
 
-export function RecordAttributeSection(props: RecordAttributeSectionProps & { DefaultComponent: React.ComponentType<RecordAttributeSectionProps> }) {
-  return props.attribute.name === 'msa'
+const MSA_ATTRIBUTE_NAME = 'msa';
+const PFAMS_TABLE_NAME = 'PFams';
+const PFAMS_ACCESSION_NUMBER_ATTRIBUTE_NAME = 'accession';
+
+const PFAM_LEGEND_ATTRIBUTE_FIELD: AttributeField = {
+  name: 'legend',
+  displayName: 'Legend',
+  isDisplayable: true,
+  isSortable: false,
+  isRemovable: false,
+  truncateTo: 100,
+  formats: []
+};
+
+export function RecordAttributeSection(props: WrappedComponentProps<RecordAttributeSectionProps>) {
+  return props.attribute.name === MSA_ATTRIBUTE_NAME
     ? <MsaAttributeSection {...props} />
     : <props.DefaultComponent {...props} />;
 }
@@ -48,4 +67,76 @@ function MsaAttributeSection(props: RecordAttributeSectionProps) {
       }
     </CollapsibleSection>
   );
+}
+
+export interface RecordTableProps {
+  className?: string;
+  record: RecordInstance;
+  recordClass: RecordClass;
+  table: TableField;
+  value: TableValue;
+}
+
+function transformPfamsAttributeFields(
+  isGraphic: boolean,
+  attributeFields: AttributeField[]
+): AttributeField[] {
+  const renamedAttributeFields = attributeFields.map(
+    attributeField => attributeField.name === PFAMS_ACCESSION_NUMBER_ATTRIBUTE_NAME
+      ? { ...attributeField, displayName: 'Accession' }
+      : attributeField
+  );
+
+  return isGraphic
+    ? [...renamedAttributeFields, PFAM_LEGEND_ATTRIBUTE_FIELD]
+    : renamedAttributeFields;
+}
+
+function transformPfamsTableRow(
+  isGraphic: boolean = true,
+  row: Record<string, AttributeValue>
+): Record<string, AttributeValue> {
+  const accessionValue = row[PFAMS_ACCESSION_NUMBER_ATTRIBUTE_NAME];
+
+  // The accession value should be rendered as a link, and if
+  // the table is in "graphic" mode, a value for the "legend" column should
+  // be provided
+  return {
+    ...row,
+    [PFAMS_ACCESSION_NUMBER_ATTRIBUTE_NAME]: typeof accessionValue === 'string'
+      ? { url: `http://pfam.xfam.org/family/${accessionValue}`, displayText: accessionValue }
+      : accessionValue,
+    legend: isGraphic && typeof accessionValue === 'string'
+      ? renderToStaticMarkup(<PfamDomain pfamId={accessionValue} />)
+      : null
+  };
+}
+
+const attributeFieldTransforms: Record<string, (afs: AttributeField[]) => AttributeField[]> = {
+  [PFAMS_TABLE_NAME]: afs => transformPfamsAttributeFields(true, afs)
+};
+
+const tableRowTransforms: Record<string, (row: Record<string, AttributeValue>) => Record<string, AttributeValue>> = {
+  [PFAMS_TABLE_NAME]: row => transformPfamsTableRow(true, row)
+};
+
+export function RecordTable(props: WrappedComponentProps<RecordTableProps>) {
+  const transformedTable = useMemo(
+    () => props.table.name in attributeFieldTransforms
+      ? {
+          ...props.table,
+          attributes: attributeFieldTransforms[props.table.name](props.table.attributes)
+        }
+      : props.table,
+    [ props.table ]
+  );
+
+  const transformedValue = useMemo(
+    () => props.table.name in tableRowTransforms
+      ? props.value.map(tableRowTransforms[props.table.name])
+      : props.value,
+    [ props.value, props.table.name ]
+  );
+
+  return <props.DefaultComponent {...props} table={transformedTable} value={transformedValue} />;
 }

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
@@ -6,16 +6,21 @@ import { curry, groupBy, isNaN, uniqBy } from 'lodash';
 import { CollapsibleSection } from 'wdk-client/Components';
 import { AttributeField, AttributeValue } from 'wdk-client/Utils/WdkModel';
 
-import { Domain, PfamDomainArchitecture } from '../components/pfam-domains/PfamDomainArchitecture';
+import { PfamDomainArchitecture } from '../components/pfam-domains/PfamDomainArchitecture';
+
 import { RecordAttributeSectionProps, RecordTableProps, WrappedComponentProps } from './Types';
 import {
+  ACCESSION_ATTRIBUTE_NAME,
+  DOMAIN_END_ATTRIBUTE_NAME,
+  DOMAIN_START_ATTRIBUTE_NAME,
   PFAM_DOMAINS_ATTRIBUTE_FIELD,
   PFAM_LEGEND_ATTRIBUTE_FIELD,
+  extractPfamDomain,
   makeCommonRecordTableWrapper,
   makeDomainAccessionLink,
   makePfamLegendMarkup,
   makeSourceAccessionLink,
-  transformAttributeFieldsUsingSpecs,
+  transformAttributeFieldsUsingSpecs
 } from './utils'
 
 import './GroupRecordClasses.GroupRecordClass.scss';
@@ -25,10 +30,7 @@ const MSA_ATTRIBUTE_NAME = 'msa';
 const PFAMS_TABLE_NAME = 'PFams';
 const PROTEIN_PFAMS_TABLE_NAME = 'ProteinPFams';
 
-const ACCESSION_NUMBER_ATTRIBUTE_NAME = 'accession';
-const CORE_PERIPHERAL_NAME = 'core_peripheral';
-const DOMAIN_START_ATTRIBUTE_NAME = 'start_min';
-const DOMAIN_END_ATTRIBUTE_NAME = 'end_max';
+const CORE_PERIPHERAL_ATTRIBUTE_NAME = 'core_peripheral';
 const PROTEIN_LENGTH_ATTRIBUTE_NAME = 'protein_length';
 const SOURCE_ID_ATTRIBUTE_NAME = 'full_id';
 
@@ -80,7 +82,7 @@ const transformPfamsAttributeFields = curry((
   attributeFields: AttributeField[]
 ): AttributeField[] => {
   const renamedAttributeFields = attributeFields.map(
-    attributeField => attributeField.name === ACCESSION_NUMBER_ATTRIBUTE_NAME
+    attributeField => attributeField.name === ACCESSION_ATTRIBUTE_NAME
       ? { ...attributeField, displayName: 'Accession' }
       : attributeField
   );
@@ -97,14 +99,14 @@ const transformPfamsTableRow = curry((
   isGraphic: boolean,
   row: Record<string, AttributeValue>
 ): Record<string, AttributeValue> => {
-  const accessionValue = row[ACCESSION_NUMBER_ATTRIBUTE_NAME];
+  const accessionValue = row[ACCESSION_ATTRIBUTE_NAME];
 
   // The accession value should be rendered as a link, and if
   // the table is in "graphic" mode, a value for the "legend" column should
   // be provided
   return {
     ...row,
-    [ACCESSION_NUMBER_ATTRIBUTE_NAME]: typeof accessionValue === 'string'
+    [ACCESSION_ATTRIBUTE_NAME]: typeof accessionValue === 'string'
       ? makeDomainAccessionLink(accessionValue)
       : accessionValue,
     legend: isGraphic && typeof accessionValue === 'string'
@@ -123,7 +125,7 @@ const makeProteinDomainLocationAttributeFields = transformAttributeFieldsUsingSp
       displayName: 'Accession'
     },
     {
-      name: CORE_PERIPHERAL_NAME,
+      name: CORE_PERIPHERAL_ATTRIBUTE_NAME,
       displayName: 'Core/Peripheral'
     },
     {
@@ -131,7 +133,7 @@ const makeProteinDomainLocationAttributeFields = transformAttributeFieldsUsingSp
       displayName: 'Protein Length'
     },
     {
-      name: ACCESSION_NUMBER_ATTRIBUTE_NAME,
+      name: ACCESSION_ATTRIBUTE_NAME,
       displayName: 'Pfam Domain'
     },
     {
@@ -152,7 +154,7 @@ const makeProteinDomainArchitectureAttributeFields = transformAttributeFieldsUsi
       displayName: 'Accession'
     },
     {
-      name: CORE_PERIPHERAL_NAME,
+      name: CORE_PERIPHERAL_ATTRIBUTE_NAME,
       displayName: 'Core/Peripheral'
     },
     {
@@ -234,26 +236,6 @@ function makePfamDomainMarkup(rowGroup: Record<string, AttributeValue>[], maxLen
         />
       )
     : '';
-}
-
-function extractPfamDomain(row: Record<string, AttributeValue>): Domain[] {
-  const pfamIdAttributeValue = row[ACCESSION_NUMBER_ATTRIBUTE_NAME];
-  const domainStartAttributeValue = row[DOMAIN_START_ATTRIBUTE_NAME];
-  const domainEndAttributeValue = row[DOMAIN_END_ATTRIBUTE_NAME];
-
-  return (
-    typeof pfamIdAttributeValue === 'string' &&
-    typeof domainStartAttributeValue === 'string' &&
-    typeof domainEndAttributeValue === 'string'
-  )
-    ? [
-        {
-          pfamId: pfamIdAttributeValue,
-          start: Number(domainStartAttributeValue),
-          end: Number(domainEndAttributeValue)
-        }
-      ]
-    : [];
 }
 
 const recordTableWrappers: Record<string, React.ComponentType<WrappedComponentProps<RecordTableProps>>> = {

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
@@ -71,6 +71,7 @@ function MsaAttributeSection(props: RecordAttributeSectionProps) {
 
 export function RecordTable(props: WrappedComponentProps<RecordTableProps>) {
   const Component = recordTableWrappers[props.table.name] ?? props.DefaultComponent;
+
   return <Component {...props} />;
 }
 

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
@@ -32,7 +32,6 @@ const DOMAIN_END_ATTRIBUTE_NAME = 'end_max';
 const PROTEIN_LENGTH_ATTRIBUTE_NAME = 'protein_length';
 const SOURCE_ID_ATTRIBUTE_NAME = 'full_id';
 
-
 export function RecordAttributeSection(props: WrappedComponentProps<RecordAttributeSectionProps>) {
   const Component = recordAttributeSectionWrappers[props.attribute.name] ?? props.DefaultComponent;
 

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
@@ -1,16 +1,13 @@
 import React, { useMemo } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
-import { requestPartialRecord } from 'wdk-client/Actions/RecordActions';
 import { CollapsibleSection } from 'wdk-client/Components';
-import { CategoryTreeNode } from 'wdk-client/Utils/CategoryUtils';
-import { AttributeField, AttributeValue, RecordClass, RecordInstance, TableField, TableValue } from 'wdk-client/Utils/WdkModel';
+import { AttributeField, AttributeValue } from 'wdk-client/Utils/WdkModel';
 
 import { PfamDomain } from '../components/pfam-domains/PfamDomain';
+import { RecordAttributeSectionProps, RecordTableProps,  WrappedComponentProps } from './Types';
 
 import './GroupRecordClasses.GroupRecordClass.scss';
-
-type WrappedComponentProps<T> = T & { DefaultComponent: React.ComponentType<T> };
 
 const MSA_ATTRIBUTE_NAME = 'msa';
 const PFAMS_TABLE_NAME = 'PFams';
@@ -25,16 +22,6 @@ const PFAM_LEGEND_ATTRIBUTE_FIELD: AttributeField = {
   truncateTo: 100,
   formats: []
 };
-
-export interface RecordAttributeSectionProps {
-  attribute: AttributeField;
-  isCollapsed: boolean;
-  onCollapsedChange: () => void;
-  ontologyProperties: CategoryTreeNode['properties'];
-  record: RecordInstance;
-  recordClass: RecordClass;
-  requestPartialRecord: typeof requestPartialRecord;
-}
 
 export function RecordAttributeSection(props: WrappedComponentProps<RecordAttributeSectionProps>) {
   return props.attribute.name === MSA_ATTRIBUTE_NAME
@@ -69,13 +56,6 @@ function MsaAttributeSection(props: RecordAttributeSectionProps) {
   );
 }
 
-export interface RecordTableProps {
-  className?: string;
-  record: RecordInstance;
-  recordClass: RecordClass;
-  table: TableField;
-  value: TableValue;
-}
 
 export function RecordTable(props: WrappedComponentProps<RecordTableProps>) {
   const transformedTable = useMemo(

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
@@ -4,9 +4,8 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { curry, groupBy, isNaN, uniqBy } from 'lodash';
 
 import { CollapsibleSection } from 'wdk-client/Components';
-import { AttributeField, AttributeValue, LinkAttributeValue } from 'wdk-client/Utils/WdkModel';
+import { AttributeField, AttributeValue } from 'wdk-client/Utils/WdkModel';
 
-import { PfamDomain } from '../components/pfam-domains/PfamDomain';
 import { Domain, PfamDomainArchitecture } from '../components/pfam-domains/PfamDomainArchitecture';
 import { RecordAttributeSectionProps, RecordTableProps, WrappedComponentProps } from './Types';
 import {
@@ -14,9 +13,10 @@ import {
   PFAM_LEGEND_ATTRIBUTE_FIELD,
   makeCommonRecordTableWrapper,
   makeDomainAccessionLink,
+  makePfamLegendMarkup,
   makeSourceAccessionLink,
-  transformAttributeFieldsUsingSpecs
-} from './utils';
+  transformAttributeFieldsUsingSpecs,
+} from './utils'
 
 import './GroupRecordClasses.GroupRecordClass.scss';
 
@@ -108,7 +108,7 @@ const transformPfamsTableRow = curry((
       ? makeDomainAccessionLink(accessionValue)
       : accessionValue,
     legend: isGraphic && typeof accessionValue === 'string'
-      ? renderToStaticMarkup(<PfamDomain pfamId={accessionValue} />)
+      ? makePfamLegendMarkup(accessionValue)
       : null
   };
 });

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
@@ -14,12 +14,11 @@ import {
   PFAM_LEGEND_ATTRIBUTE_FIELD,
   makeCommonRecordTableWrapper,
   makeDomainAccessionLink,
+  makeSourceAccessionLink,
   transformAttributeFieldsUsingSpecs
 } from './utils';
 
 import './GroupRecordClasses.GroupRecordClass.scss';
-
-const SEQUENCE_RECORD_URL_SEGMENT = '/a/app/record/sequence';
 
 const MSA_ATTRIBUTE_NAME = 'msa';
 
@@ -170,7 +169,7 @@ function makeProteinDomainLocationsTableRow(row: Record<string, AttributeValue>)
   return {
     ...row,
     [SOURCE_ID_ATTRIBUTE_NAME]: typeof accessionValue === 'string'
-      ? makeAccessionLink(accessionValue)
+      ? makeSourceAccessionLink(accessionValue)
       : accessionValue
   };
 }
@@ -209,7 +208,7 @@ function RecordTable_ProteinDomainArchitectures(props: WrappedComponentProps<Rec
         return typeof accessionValue === 'string'
           ? {
               ...row,
-              [SOURCE_ID_ATTRIBUTE_NAME]: makeAccessionLink(accessionValue),
+              [SOURCE_ID_ATTRIBUTE_NAME]: makeSourceAccessionLink(accessionValue),
               [PFAM_DOMAINS_ATTRIBUTE_FIELD.name]: makePfamDomainMarkup(rowsByAccession[accessionValue], maxLength)
             }
           : row;
@@ -220,13 +219,6 @@ function RecordTable_ProteinDomainArchitectures(props: WrappedComponentProps<Rec
   }, [ props.value ]);
 
   return <props.DefaultComponent {...props} table={transformedTable} value={transformedRecords} />;
-}
-
-function makeAccessionLink(accession: string): LinkAttributeValue {
-  return {
-    url: `${SEQUENCE_RECORD_URL_SEGMENT}/${accession}`,
-    displayText: accession
-  };
 }
 
 function makePfamDomainMarkup(rowGroup: Record<string, AttributeValue>[], maxLength: number): string {

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { requestPartialRecord } from 'wdk-client/Actions/RecordActions';
+import { CollapsibleSection } from 'wdk-client/Components';
+import { CategoryTreeNode } from 'wdk-client/Utils/CategoryUtils';
+import { RecordClass, RecordInstance, Reporter } from 'wdk-client/Utils/WdkModel';
+
+import './GroupRecordClasses.GroupRecordClass.scss';
+
+export interface RecordAttributeSectionProps {
+  attribute: Reporter;
+  isCollapsed: boolean;
+  onCollapsedChange: () => void;
+  ontologyProperties: CategoryTreeNode['properties'];
+  record: RecordInstance;
+  recordClass: RecordClass;
+  requestPartialRecord: typeof requestPartialRecord;
+}
+
+export function RecordAttributeSection(props: RecordAttributeSectionProps & { DefaultComponent: React.ComponentType<RecordAttributeSectionProps> }) {
+  return props.attribute.name === 'msa'
+    ? <MsaAttributeSection {...props} />
+    : <props.DefaultComponent {...props} />;
+}
+
+function MsaAttributeSection(props: RecordAttributeSectionProps) {
+  const { isCollapsed, onCollapsedChange } = props;
+  const { name: attributeName, displayName: attributeDisplayName } = props.attribute;
+
+  const msaValue = props.record.attributes[attributeName];
+
+  return (
+    <CollapsibleSection
+      id={attributeName}
+      className="wdk-RecordAttributeSectionItem"
+      headerContent={attributeDisplayName}
+      isCollapsed={isCollapsed}
+      onCollapsedChange={onCollapsedChange}
+    >
+      {
+        typeof msaValue !== 'string'
+          ? <div className="wdk-MissingMsaAttribute">
+              We're sorry, multiple sequence alignments are only available for groups with 100 or fewer sequences.
+            </div>
+          : <pre>
+              {msaValue}
+            </pre>
+      }
+    </CollapsibleSection>
+  );
+}

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
@@ -10,10 +10,11 @@ import { PfamDomain } from '../components/pfam-domains/PfamDomain';
 import { Domain, PfamDomainArchitecture } from '../components/pfam-domains/PfamDomainArchitecture';
 import { RecordAttributeSectionProps, RecordTableProps, WrappedComponentProps } from './Types';
 import {
-  makeCommonRecordTableWrapper,
-  transformAttributeFieldsUsingSpecs,
   PFAM_DOMAINS_ATTRIBUTE_FIELD,
-  PFAM_LEGEND_ATTRIBUTE_FIELD
+  PFAM_LEGEND_ATTRIBUTE_FIELD,
+  makeCommonRecordTableWrapper,
+  makeDomainAccessionLink,
+  transformAttributeFieldsUsingSpecs
 } from './utils';
 
 import './GroupRecordClasses.GroupRecordClass.scss';
@@ -105,7 +106,7 @@ const transformPfamsTableRow = curry((
   return {
     ...row,
     [ACCESSION_NUMBER_ATTRIBUTE_NAME]: typeof accessionValue === 'string'
-      ? { url: `http://pfam.xfam.org/family/${accessionValue}`, displayText: accessionValue }
+      ? makeDomainAccessionLink(accessionValue)
       : accessionValue,
     legend: isGraphic && typeof accessionValue === 'string'
       ? renderToStaticMarkup(<PfamDomain pfamId={accessionValue} />)

--- a/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.scss
+++ b/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.scss
@@ -1,0 +1,3 @@
+.wdk-RecordContainer__SequenceRecordClasses\.SequenceRecordClass {
+
+}

--- a/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.scss
+++ b/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.scss
@@ -1,3 +1,15 @@
 .wdk-RecordContainer__SequenceRecordClasses\.SequenceRecordClass {
+  .DomainArchitectureHeader {
+    font-size: 1.2em;
+    font-weight: 500;
+    margin-bottom: 0.5em;
+  }
 
+  .PfamDomainArchitecture {
+    margin-bottom: 2.5em;
+    border-left: 0.0625rem dotted black;
+    border-right: 0.0625rem dotted black;
+    padding: 1.5em;
+    background-color: #f5f5f5;
+  }
 }

--- a/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
@@ -1,0 +1,21 @@
+import React, { useMemo } from 'react';
+
+import { RecordTableProps, WrappedComponentProps } from './Types';
+
+import './SequenceRecordClasses.SequenceRecordClass.scss';
+
+const PFAM_DOMAINS_TABLE_NAME = 'PFamDomains';
+
+export function RecordTable(props: WrappedComponentProps<RecordTableProps>) {
+  const Component = recordTableWrappers[props.table.name] ?? props.DefaultComponent;
+
+  return <Component {...props} />;
+}
+
+function RecordTable_PfamDomains(props: WrappedComponentProps<RecordTableProps>) {
+  return <props.DefaultComponent {...props} />;
+}
+
+const recordTableWrappers: Record<string, React.ComponentType<WrappedComponentProps<RecordTableProps>>> = {
+  [PFAM_DOMAINS_TABLE_NAME]: RecordTable_PfamDomains
+};

--- a/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
@@ -77,7 +77,11 @@ const PfamDomainsTable = makeCommonRecordTableWrapper(
 
 function RecordTable_PfamDomains(props: WrappedComponentProps<RecordTableProps>) {
   const length = Number(props.record.attributes[DOMAIN_LENGTH_ATTRIBUTE_NAME]);
-  const domains = props.value.flatMap(extractPfamDomain);
+
+  const domains = useMemo(
+    () => props.value.flatMap(extractPfamDomain),
+    [ props.value ]
+  );
 
   return (
     <div className="PfamDomainsContent">

--- a/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
@@ -2,24 +2,29 @@ import React, { useMemo } from 'react';
 
 import { AttributeValue } from 'wdk-client/Utils/WdkModel';
 
-import { RecordTableProps, WrappedComponentProps } from './Types';
+import { PfamDomainArchitecture } from '../components/pfam-domains/PfamDomainArchitecture';
 
-import './SequenceRecordClasses.SequenceRecordClass.scss';
 import {
+  DOMAIN_END_ATTRIBUTE_NAME,
+  DOMAIN_START_ATTRIBUTE_NAME,
   PFAM_LEGEND_ATTRIBUTE_FIELD,
   makeCommonRecordTableWrapper,
   makeDomainAccessionLink,
   transformAttributeFieldsUsingSpecs,
-  makePfamLegendMarkup
+  makePfamLegendMarkup,
+  extractPfamDomain
 } from './utils';
+
+import { RecordTableProps, WrappedComponentProps } from './Types';
+
+import './SequenceRecordClasses.SequenceRecordClass.scss';
 
 const PFAM_DOMAINS_TABLE_NAME = 'PFamDomains';
 
 const DOMAIN_ACCESSION_ATTRIBUTE_NAME = 'accession';
-const DOMAIN_SYMBOL_ATTRIBUTE_NAME = 'symbol';
+const DOMAIN_LENGTH_ATTRIBUTE_NAME = 'length';
 const DOMAIN_DESCRIPTION_ATTRIBUTE_NAME = 'description';
-const DOMAIN_START_ATTRIBUTE_NAME = 'start_min';
-const DOMAIN_END_ATTRIBUTE_NAME = 'end_max';
+const DOMAIN_SYMBOL_ATTRIBUTE_NAME = 'symbol';
 
 export function RecordTable(props: WrappedComponentProps<RecordTableProps>) {
   const Component = recordTableWrappers[props.table.name] ?? props.DefaultComponent;
@@ -65,10 +70,28 @@ function makePfamDomainsTableRow(row: Record<string, AttributeValue>) {
   };
 }
 
-const RecordTable_PfamDomains = makeCommonRecordTableWrapper(
+const PfamDomainsTable = makeCommonRecordTableWrapper(
   makePfamDomainsAttributeFields,
   makePfamDomainsTableRow
 );
+
+function RecordTable_PfamDomains(props: WrappedComponentProps<RecordTableProps>) {
+  const length = Number(props.record.attributes[DOMAIN_LENGTH_ATTRIBUTE_NAME]);
+  const domains = props.value.flatMap(extractPfamDomain);
+
+  return (
+    <div className="PfamDomainsContent">
+      <div className="DomainArchitectureHeader">
+        Domain Architecture
+      </div>
+      <PfamDomainArchitecture
+        length={length}
+        domains={domains}
+      />
+      <PfamDomainsTable {...props} />
+    </div>
+  )
+}
 
 const recordTableWrappers: Record<string, React.ComponentType<WrappedComponentProps<RecordTableProps>>> = {
   [PFAM_DOMAINS_TABLE_NAME]: RecordTable_PfamDomains

--- a/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
@@ -1,9 +1,16 @@
 import React, { useMemo } from 'react';
 
+import { AttributeValue } from 'wdk-client/Utils/WdkModel';
+
 import { RecordTableProps, WrappedComponentProps } from './Types';
 
 import './SequenceRecordClasses.SequenceRecordClass.scss';
-import { makeCommonRecordTableWrapper, transformAttributeFieldsUsingSpecs, PFAM_LEGEND_ATTRIBUTE_FIELD } from './utils';
+import {
+  PFAM_LEGEND_ATTRIBUTE_FIELD,
+  makeCommonRecordTableWrapper,
+  makeDomainAccessionLink,
+  transformAttributeFieldsUsingSpecs
+} from './utils';
 
 const PFAM_DOMAINS_TABLE_NAME = 'PFamDomains';
 
@@ -43,9 +50,20 @@ const makePfamDomainsAttributeFields = transformAttributeFieldsUsingSpecs([
   PFAM_LEGEND_ATTRIBUTE_FIELD
 ]);
 
+function makePfamDomainsTableRow(row: Record<string, AttributeValue>) {
+  const accessionValue = row[DOMAIN_ACCESSION_ATTRIBUTE_NAME];
+
+  return {
+    ...row,
+    [DOMAIN_ACCESSION_ATTRIBUTE_NAME]: typeof accessionValue === 'string'
+      ? makeDomainAccessionLink(accessionValue)
+      : accessionValue
+  };
+}
+
 const RecordTable_PfamDomains = makeCommonRecordTableWrapper(
   makePfamDomainsAttributeFields,
-  table => table
+  makePfamDomainsTableRow
 );
 
 const recordTableWrappers: Record<string, React.ComponentType<WrappedComponentProps<RecordTableProps>>> = {

--- a/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
@@ -3,8 +3,15 @@ import React, { useMemo } from 'react';
 import { RecordTableProps, WrappedComponentProps } from './Types';
 
 import './SequenceRecordClasses.SequenceRecordClass.scss';
+import { makeCommonRecordTableWrapper, transformAttributeFieldsUsingSpecs, PFAM_LEGEND_ATTRIBUTE_FIELD } from './utils';
 
 const PFAM_DOMAINS_TABLE_NAME = 'PFamDomains';
+
+const DOMAIN_ACCESSION_ATTRIBUTE_NAME = 'accession';
+const DOMAIN_SYMBOL_ATTRIBUTE_NAME = 'symbol';
+const DOMAIN_DESCRIPTION_ATTRIBUTE_NAME = 'description';
+const DOMAIN_START_ATTRIBUTE_NAME = 'start_min';
+const DOMAIN_END_ATTRIBUTE_NAME = 'end_max';
 
 export function RecordTable(props: WrappedComponentProps<RecordTableProps>) {
   const Component = recordTableWrappers[props.table.name] ?? props.DefaultComponent;
@@ -12,9 +19,34 @@ export function RecordTable(props: WrappedComponentProps<RecordTableProps>) {
   return <Component {...props} />;
 }
 
-function RecordTable_PfamDomains(props: WrappedComponentProps<RecordTableProps>) {
-  return <props.DefaultComponent {...props} />;
-}
+const makePfamDomainsAttributeFields = transformAttributeFieldsUsingSpecs([
+  {
+    name: DOMAIN_ACCESSION_ATTRIBUTE_NAME,
+    displayName: 'Accession'
+  },
+  {
+    name: DOMAIN_SYMBOL_ATTRIBUTE_NAME,
+    displayName: 'Name'
+  },
+  {
+    name: DOMAIN_DESCRIPTION_ATTRIBUTE_NAME,
+    displayName: 'Description'
+  },
+  {
+    name: DOMAIN_START_ATTRIBUTE_NAME,
+    displayName: 'Start'
+  },
+  {
+    name: DOMAIN_END_ATTRIBUTE_NAME,
+    displayName: 'End'
+  },
+  PFAM_LEGEND_ATTRIBUTE_FIELD
+]);
+
+const RecordTable_PfamDomains = makeCommonRecordTableWrapper(
+  makePfamDomainsAttributeFields,
+  table => table
+);
 
 const recordTableWrappers: Record<string, React.ComponentType<WrappedComponentProps<RecordTableProps>>> = {
   [PFAM_DOMAINS_TABLE_NAME]: RecordTable_PfamDomains

--- a/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
@@ -9,7 +9,8 @@ import {
   PFAM_LEGEND_ATTRIBUTE_FIELD,
   makeCommonRecordTableWrapper,
   makeDomainAccessionLink,
-  transformAttributeFieldsUsingSpecs
+  transformAttributeFieldsUsingSpecs,
+  makePfamLegendMarkup
 } from './utils';
 
 const PFAM_DOMAINS_TABLE_NAME = 'PFamDomains';
@@ -57,6 +58,9 @@ function makePfamDomainsTableRow(row: Record<string, AttributeValue>) {
     ...row,
     [DOMAIN_ACCESSION_ATTRIBUTE_NAME]: typeof accessionValue === 'string'
       ? makeDomainAccessionLink(accessionValue)
+      : accessionValue,
+    [PFAM_LEGEND_ATTRIBUTE_FIELD.name]: typeof accessionValue === 'string'
+      ? makePfamLegendMarkup(accessionValue)
       : accessionValue
   };
 }

--- a/Site/webapp/wdkCustomization/js/client/records/Types.ts
+++ b/Site/webapp/wdkCustomization/js/client/records/Types.ts
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { requestPartialRecord } from 'wdk-client/Actions/RecordActions';
+import { AttributeField, RecordInstance, RecordClass, TableField, TableValue } from 'wdk-client/Utils/WdkModel';
+import { CategoryTreeNode } from 'wdk-client/Utils/CategoryUtils';
+
+export type WrappedComponentProps<T> = T & { DefaultComponent: React.ComponentType<T> };
+
+export interface RecordAttributeSectionProps {
+  attribute: AttributeField;
+  isCollapsed: boolean;
+  onCollapsedChange: () => void;
+  ontologyProperties: CategoryTreeNode['properties'];
+  record: RecordInstance;
+  recordClass: RecordClass;
+  requestPartialRecord: typeof requestPartialRecord;
+}
+
+export interface RecordTableProps {
+  className?: string;
+  record: RecordInstance;
+  recordClass: RecordClass;
+  table: TableField;
+  value: TableValue;
+}

--- a/Site/webapp/wdkCustomization/js/client/records/utils.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/utils.tsx
@@ -84,3 +84,6 @@ export const transformAttributeFieldsUsingSpecs = curry((
   return reorderedAttributeFields;
 });
 
+export function makeDomainAccessionLink(accession: string) {
+  return { url: `http://pfam.xfam.org/family/${accession}`, displayText: accession };
+}

--- a/Site/webapp/wdkCustomization/js/client/records/utils.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/utils.tsx
@@ -1,10 +1,12 @@
 import React, { useMemo } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 import { curry, orderBy } from 'lodash'
 
 import { AttributeField, AttributeValue, LinkAttributeValue } from 'wdk-client/Utils/WdkModel';
 
 import { RecordTableProps, WrappedComponentProps } from './Types';
+import { PfamDomain } from '../components/pfam-domains/PfamDomain';
 
 export const PFAM_LEGEND_ATTRIBUTE_FIELD: AttributeField = {
   name: 'legend',
@@ -93,4 +95,8 @@ export function makeSourceAccessionLink(accession: string): LinkAttributeValue {
     url: `/a/app/record/sequence/${accession}`,
     displayText: accession
   };
+}
+
+export function makePfamLegendMarkup(pfamId: string) {
+  return renderToStaticMarkup(<PfamDomain pfamId={pfamId} />);
 }

--- a/Site/webapp/wdkCustomization/js/client/records/utils.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/utils.tsx
@@ -1,0 +1,82 @@
+import React, { useMemo } from 'react';
+
+import { curry, orderBy } from 'lodash'
+
+import { AttributeField, AttributeValue } from 'wdk-client/Utils/WdkModel';
+
+import { RecordTableProps, WrappedComponentProps } from './Types';
+
+export const PFAM_LEGEND_ATTRIBUTE_FIELD: AttributeField = {
+  name: 'legend',
+  displayName: 'Legend',
+  isDisplayable: true,
+  isSortable: false,
+  isRemovable: false,
+  truncateTo: 100,
+  formats: []
+};
+
+export const PFAM_DOMAINS_ATTRIBUTE_FIELD: AttributeField = {
+  name: 'domains',
+  displayName: ' ',
+  isDisplayable: true,
+  isSortable: false,
+  isRemovable: false,
+  truncateTo: 100,
+  formats: []
+};
+
+interface PseudoAttributeSpec {
+  name: string;
+  displayName: string;
+}
+
+export const makeCommonRecordTableWrapper = curry((
+  makeAttributeFields: (ads: AttributeField[]) => AttributeField[],
+  makeTableRow: (row: Record<string, AttributeValue>) => Record<string, AttributeValue>,
+  props: WrappedComponentProps<RecordTableProps>
+) => {
+  const transformedTable = useMemo(
+    () => ({
+      ...props.table,
+      attributes: makeAttributeFields(props.table.attributes)
+    }),
+    []
+  );
+
+  const transformedValue = useMemo(
+    () => props.value.map(makeTableRow),
+    [ props.value ]
+  );
+
+  return <props.DefaultComponent {...props} table={transformedTable} value={transformedValue} />;
+});
+
+export const transformAttributeFieldsUsingSpecs = curry((
+  pseudoAttributeSpecs: PseudoAttributeSpec[],
+  attributeFields: AttributeField[]
+): AttributeField[] => {
+  const augmentedAttributeFields = [...attributeFields, PFAM_DOMAINS_ATTRIBUTE_FIELD];
+
+  const filteredAttributeFields = augmentedAttributeFields.filter(
+    attributeField => pseudoAttributeSpecs.find(pa => pa.name === attributeField.name)
+  );
+
+  const attributeDisplayNames = new Map(pseudoAttributeSpecs.map(pa => [pa.name, pa.displayName]));
+
+  const renamedAttributeFields = filteredAttributeFields.map(
+    attributeField =>
+      ({
+        ...attributeField,
+        displayName: attributeDisplayNames.get(attributeField.name) ?? attributeField.name
+      })
+  );
+
+  const reorderedAttributeFields = orderBy(
+    renamedAttributeFields,
+    attributeField => pseudoAttributeSpecs.findIndex(pa => pa.name === attributeField.name)
+  );
+
+  return reorderedAttributeFields;
+});
+

--- a/Site/webapp/wdkCustomization/js/client/records/utils.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/utils.tsx
@@ -56,7 +56,11 @@ export const transformAttributeFieldsUsingSpecs = curry((
   pseudoAttributeSpecs: PseudoAttributeSpec[],
   attributeFields: AttributeField[]
 ): AttributeField[] => {
-  const augmentedAttributeFields = [...attributeFields, PFAM_DOMAINS_ATTRIBUTE_FIELD];
+  const augmentedAttributeFields = [
+    ...attributeFields,
+    PFAM_LEGEND_ATTRIBUTE_FIELD,
+    PFAM_DOMAINS_ATTRIBUTE_FIELD
+  ];
 
   const filteredAttributeFields = augmentedAttributeFields.filter(
     attributeField => pseudoAttributeSpecs.find(pa => pa.name === attributeField.name)

--- a/Site/webapp/wdkCustomization/js/client/records/utils.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/utils.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 
 import { curry, orderBy } from 'lodash'
 
-import { AttributeField, AttributeValue } from 'wdk-client/Utils/WdkModel';
+import { AttributeField, AttributeValue, LinkAttributeValue } from 'wdk-client/Utils/WdkModel';
 
 import { RecordTableProps, WrappedComponentProps } from './Types';
 
@@ -86,4 +86,11 @@ export const transformAttributeFieldsUsingSpecs = curry((
 
 export function makeDomainAccessionLink(accession: string) {
   return { url: `http://pfam.xfam.org/family/${accession}`, displayText: accession };
+}
+
+export function makeSourceAccessionLink(accession: string): LinkAttributeValue {
+  return {
+    url: `/a/app/record/sequence/${accession}`,
+    displayText: accession
+  };
 }

--- a/Site/webapp/wdkCustomization/js/client/records/utils.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/utils.tsx
@@ -5,8 +5,14 @@ import { curry, orderBy } from 'lodash'
 
 import { AttributeField, AttributeValue, LinkAttributeValue } from 'wdk-client/Utils/WdkModel';
 
-import { RecordTableProps, WrappedComponentProps } from './Types';
 import { PfamDomain } from '../components/pfam-domains/PfamDomain';
+import { Domain } from '../components/pfam-domains/PfamDomainArchitecture';
+
+import { RecordTableProps, WrappedComponentProps } from './Types';
+
+export const ACCESSION_ATTRIBUTE_NAME = 'accession';
+export const DOMAIN_START_ATTRIBUTE_NAME = 'start_min';
+export const DOMAIN_END_ATTRIBUTE_NAME = 'end_max';
 
 export const PFAM_LEGEND_ATTRIBUTE_FIELD: AttributeField = {
   name: 'legend',
@@ -99,4 +105,24 @@ export function makeSourceAccessionLink(accession: string): LinkAttributeValue {
 
 export function makePfamLegendMarkup(pfamId: string) {
   return renderToStaticMarkup(<PfamDomain pfamId={pfamId} />);
+}
+
+export function extractPfamDomain(row: Record<string, AttributeValue>): Domain[] {
+  const pfamIdAttributeValue = row[ACCESSION_ATTRIBUTE_NAME];
+  const domainStartAttributeValue = row[DOMAIN_START_ATTRIBUTE_NAME];
+  const domainEndAttributeValue = row[DOMAIN_END_ATTRIBUTE_NAME];
+
+  return (
+    typeof pfamIdAttributeValue === 'string' &&
+    typeof domainStartAttributeValue === 'string' &&
+    typeof domainEndAttributeValue === 'string'
+  )
+    ? [
+        {
+          pfamId: pfamIdAttributeValue,
+          start: Number(domainStartAttributeValue),
+          end: Number(domainEndAttributeValue)
+        }
+      ]
+    : [];
 }

--- a/Site/webapp/wdkCustomization/js/client/utils/pfamDomain.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/pfamDomain.ts
@@ -1,0 +1,49 @@
+// change this to have more/less bands
+const BAND_COUNT = 4;
+
+// 13 colors used for 4-band domain coloring
+const COLORS = [
+  "rgb(71, 145, 213)",  // dark blue
+  "rgb(193, 235, 248)", // light blue
+  "orange",
+  "rgb(235, 235, 0)",  // yellow
+  "black",
+  "rgb(190, 190, 190)", // grey
+  "rgb(255, 192, 203)", // light red
+  "rgb(223, 42, 42)",   // dark red
+  "rgb(144, 238, 144)", // light green
+  "rgb(0, 145, 0)",     // dark green
+  "rgb(216, 87, 216)",  // purple
+  "rgb(206, 169, 73)",  // brown
+  "white"
+];
+
+// COLORS is a curated list of colors. Four colors are combined based on
+// the pfam ID (see below) to create a 4-band coloring. The number 4 was
+// chosen with the idea that the number of pfam domains would not surpass
+// 13^4 (28,561) for quite some time. If it does, then untouched, this
+// will scale to 5 bands (where appropriate). This will also scale if
+// additional colors are added.
+//
+// The pfam ID is of the form "PF#####" where the numbers are sequential.
+// We will slice out the numeric part of the ID and compute its elements
+// in base {COLORS.length}.
+//
+// Number.toString will do this with a numeric argument. The values are 0-indexed.
+// For values larger than 9, lowercase alpha characters are used beginning
+// with "a".
+//
+// Likewise, parseInt will convert a String to a Number in the given radix.
+export function assignColors(pfamId: string) {
+  // Parse the numeric part of the Pfam ID as an integer and get its
+  // elements in base {COLORS.length}
+  const terms = parseInt(pfamId.slice(2), 10).toString(COLORS.length);
+
+  // Pad with zeros so we can get the number of colors needed
+  const paddedTerms = terms.padStart(BAND_COUNT, '0');
+
+  // Transform each term into a color
+  return [...paddedTerms].map(
+    term => COLORS[parseInt(term, COLORS.length)]
+  );
+}


### PR DESCRIPTION
This PR provides...

* Initial `component-wrappers.ts` boilerplate for Ortho record pages (most notably, an Ortho version of `makeDynamicWrapper`)
* Initial implementations of most of the Group record page component wrappers (specifically the Ortho 5 version of the MSA attribute, both versions of the PFam Domains table [“graphic” and “detailed”], the Protein Domain Locations table, and the Protein Domain Architectures table)
* Initial implementation of the "Pfam Domains" table on Sequence record pages

Depends on https://github.com/VEuPathDB/OrthoMCLClient/pull/1