### PR TITLE
Initial commit of service layer + cluster graph

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/controllers/ClusterGraphController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/ClusterGraphController.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 
-export function ClusterGraphController() {
+interface Props {
+  groupName: string;
+}
+
+export function ClusterGraphController(props: Props) {
   return <div>Future home of Cluster Graph</div>;
 }

--- a/Site/webapp/wdkCustomization/js/client/controllers/ClusterGraphController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/ClusterGraphController.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export function ClusterGraphController() {
+  return <div>Future home of Cluster Graph</div>;
+}

--- a/Site/webapp/wdkCustomization/js/client/controllers/GroupClusterGraphController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/GroupClusterGraphController.tsx
@@ -5,5 +5,5 @@ interface Props {
 }
 
 export function GroupClusterGraphController(props: Props) {
-  return <div>Future home of Cluster Graph</div>;
+  return <div>A cluster graph display for {props.groupName} will be rendered here</div>;
 }

--- a/Site/webapp/wdkCustomization/js/client/controllers/GroupClusterGraphController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/GroupClusterGraphController.tsx
@@ -4,6 +4,6 @@ interface Props {
   groupName: string;
 }
 
-export function ClusterGraphController(props: Props) {
+export function GroupClusterGraphController(props: Props) {
   return <div>Future home of Cluster Graph</div>;
 }

--- a/Site/webapp/wdkCustomization/js/client/hooks/orthoServiceHook.ts
+++ b/Site/webapp/wdkCustomization/js/client/hooks/orthoServiceHook.ts
@@ -1,0 +1,15 @@
+import { ServiceCallback, useWdkService } from 'wdk-client/Hooks/WdkServiceHook';
+
+import { OrthoService, isOrthoService } from '../services';
+
+type OrthoServiceCallback<T> = ServiceCallback<OrthoService, T>;
+
+export function useOrthoService<T>(callback: OrthoServiceCallback<T>, deps?: any[]): T | undefined {
+  return useWdkService(wdkService => {
+    if (!isOrthoService(wdkService)) {
+      throw new Error("Non-Ortho service passed to 'useOrthoService'");
+    }
+
+    return callback(wdkService);
+  }, deps);
+}

--- a/Site/webapp/wdkCustomization/js/client/main.js
+++ b/Site/webapp/wdkCustomization/js/client/main.js
@@ -1,11 +1,13 @@
 import { initialize } from 'ebrc-client/bootstrap';
 import componentWrappers from './component-wrappers';
 import { wrapRoutes } from './routes';
+import { wrapWdkService } from './services';
 
 import 'eupathdb/wdkCustomization/css/client.scss';
 import '../../css/client.scss';
 
 initialize({
   componentWrappers,
-  wrapRoutes
+  wrapRoutes,
+  wrapWdkService
 });

--- a/Site/webapp/wdkCustomization/js/client/routes.tsx
+++ b/Site/webapp/wdkCustomization/js/client/routes.tsx
@@ -5,7 +5,7 @@ import { RouteComponentProps } from 'react-router';
 import { RouteEntry } from 'wdk-client/Core/RouteEntry';
 
 import { OrthoMCLHomePageController } from './controllers/OrthoMCLHomePageController';
-import { ClusterGraphController } from './controllers/ClusterGraphController';
+import { GroupClusterGraphController } from './controllers/GroupClusterGraphController';
 
 export function wrapRoutes(ebrcRoutes: RouteEntry[]): RouteEntry[] {
   return [
@@ -21,7 +21,7 @@ export function wrapRoutes(ebrcRoutes: RouteEntry[]): RouteEntry[] {
       component: (props: RouteComponentProps<{ groupName: string }>) => {
         const groupName = props.match.params.groupName;
 
-        return <ClusterGraphController groupName={groupName} />;
+        return <GroupClusterGraphController groupName={groupName} />;
       }
     },
     ...ebrcRoutes

--- a/Site/webapp/wdkCustomization/js/client/routes.tsx
+++ b/Site/webapp/wdkCustomization/js/client/routes.tsx
@@ -1,3 +1,7 @@
+import React from 'react';
+
+import { RouteComponentProps } from 'react-router';
+
 import { RouteEntry } from 'wdk-client/Core/RouteEntry';
 
 import { OrthoMCLHomePageController } from './controllers/OrthoMCLHomePageController';
@@ -14,7 +18,11 @@ export function wrapRoutes(ebrcRoutes: RouteEntry[]): RouteEntry[] {
     // TODO: of the cluster graph is complete
     {
       path: '/cluster-graph/:groupName',
-      component: ClusterGraphController
+      component: (props: RouteComponentProps<{ groupName: string }>) => {
+        const groupName = props.match.params.groupName;
+
+        return <ClusterGraphController groupName={groupName} />;
+      }
     },
     ...ebrcRoutes
   ];

--- a/Site/webapp/wdkCustomization/js/client/routes.tsx
+++ b/Site/webapp/wdkCustomization/js/client/routes.tsx
@@ -1,6 +1,7 @@
 import { RouteEntry } from 'wdk-client/Core/RouteEntry';
 
 import { OrthoMCLHomePageController } from './controllers/OrthoMCLHomePageController';
+import { ClusterGraphController } from './controllers/ClusterGraphController';
 
 export function wrapRoutes(ebrcRoutes: RouteEntry[]): RouteEntry[] {
   return [
@@ -8,6 +9,12 @@ export function wrapRoutes(ebrcRoutes: RouteEntry[]): RouteEntry[] {
       path: '/',
       component: OrthoMCLHomePageController,
       rootClassNameModifier: 'home-page'
+    },
+    // TODO: Delete this route once the initial implementation
+    // TODO: of the cluster graph is complete
+    {
+      path: '/cluster-graph/:groupName',
+      component: ClusterGraphController
     },
     ...ebrcRoutes
   ];

--- a/Site/webapp/wdkCustomization/js/client/services.tsx
+++ b/Site/webapp/wdkCustomization/js/client/services.tsx
@@ -1,6 +1,8 @@
 import { WdkService } from 'wdk-client/Core';
 import { ok } from 'wdk-client/Utils/Json';
 
+import { GroupLayout, groupLayoutDecoder } from './utils/groupLayout';
+
 export function wrapWdkService(wdkService: WdkService): OrthoService {
   return ({
     ...wdkService,
@@ -31,8 +33,8 @@ const orthoServiceWrappers = {
       }
     ),
   getGroupLayout: (wdkService: WdkService) => (groupName: string) =>
-    wdkService.sendRequest<unknown>(
-      ok,
+    wdkService.sendRequest(
+      groupLayoutDecoder,
       {
         useCache: true,
         method: 'get',
@@ -53,7 +55,7 @@ const orthoServiceWrappers = {
 export interface OrthoService extends WdkService {
   getGenomeSources: () => Promise<unknown>;
   getGenomeStatistics: () => Promise<unknown>;
-  getGroupLayout: (groupName: string) => Promise<unknown>;
+  getGroupLayout: (groupName: string) => Promise<GroupLayout>;
   getTaxons: () => Promise<unknown>;
 }
 

--- a/Site/webapp/wdkCustomization/js/client/services.tsx
+++ b/Site/webapp/wdkCustomization/js/client/services.tsx
@@ -1,0 +1,64 @@
+import { WdkService } from 'wdk-client/Core';
+import { ok } from 'wdk-client/Utils/Json';
+
+export function wrapWdkService(wdkService: WdkService): OrthoService {
+  return ({
+    ...wdkService,
+    getGenomeSources: orthoServiceWrappers.getGenomeSources(wdkService),
+    getGenomeStatistics: orthoServiceWrappers.getGenomeStatistics(wdkService),
+    getGroupLayout: orthoServiceWrappers.getGroupLayout(wdkService),
+    getTaxons: orthoServiceWrappers.getTaxons(wdkService)
+  });
+};
+
+const orthoServiceWrappers = {
+  getGenomeSources: (wdkService: WdkService) => () =>
+    wdkService.sendRequest<unknown>(
+      ok,
+      {
+        useCache: true,
+        method: 'get',
+        path: `/data-summary/genome-sources`
+      }
+    ),
+  getGenomeStatistics: (wdkService: WdkService) => () =>
+    wdkService.sendRequest<unknown>(
+      ok,
+      {
+        useCache: true,
+        method: 'get',
+        path: `/data-summary/genome-statistics`
+      }
+    ),
+  getGroupLayout: (wdkService: WdkService) => (groupName: string) =>
+    wdkService.sendRequest<unknown>(
+      ok,
+      {
+        useCache: true,
+        method: 'get',
+        path: `/group/${groupName}/layout`
+      }
+    ),
+  getTaxons: (wdkService: WdkService) => () =>
+    wdkService.sendRequest<unknown>(
+      ok,
+      {
+        useCache: true,
+        method: 'get',
+        path: `/data-summary/taxons`
+      }
+    )
+};
+
+export interface OrthoService extends WdkService {
+  getGenomeSources: () => Promise<unknown>;
+  getGenomeStatistics: () => Promise<unknown>;
+  getGroupLayout: (groupName: string) => Promise<unknown>;
+  getTaxons: () => Promise<unknown>;
+}
+
+export function isOrthoService(wdkService: WdkService): wdkService is OrthoService {
+  return Object.keys(orthoServiceWrappers).every(
+    orthoServiceKey => orthoServiceKey in wdkService
+  );
+}

--- a/Site/webapp/wdkCustomization/js/client/services.tsx
+++ b/Site/webapp/wdkCustomization/js/client/services.tsx
@@ -20,7 +20,7 @@ const orthoServiceWrappers = {
       {
         useCache: true,
         method: 'get',
-        path: `/data-summary/genome-sources`
+        path: '/data-summary/genome-sources'
       }
     ),
   getGenomeStatistics: (wdkService: WdkService) => () =>
@@ -29,7 +29,7 @@ const orthoServiceWrappers = {
       {
         useCache: true,
         method: 'get',
-        path: `/data-summary/genome-statistics`
+        path: '/data-summary/genome-statistics'
       }
     ),
   getGroupLayout: (wdkService: WdkService) => (groupName: string) =>
@@ -47,7 +47,7 @@ const orthoServiceWrappers = {
       {
         useCache: true,
         method: 'get',
-        path: `/data-summary/taxons`
+        path: '/data-summary/taxons'
       }
     )
 };

--- a/Site/webapp/wdkCustomization/js/client/services.tsx
+++ b/Site/webapp/wdkCustomization/js/client/services.tsx
@@ -2,6 +2,7 @@ import { WdkService } from 'wdk-client/Core';
 import { ok } from 'wdk-client/Utils/Json';
 
 import { GroupLayout, groupLayoutDecoder } from './utils/groupLayout';
+import { TaxonEntries, taxonEntriesDecoder } from './utils/taxons';
 
 export function wrapWdkService(wdkService: WdkService): OrthoService {
   return ({
@@ -42,8 +43,8 @@ const orthoServiceWrappers = {
       }
     ),
   getTaxons: (wdkService: WdkService) => () =>
-    wdkService.sendRequest<unknown>(
-      ok,
+    wdkService.sendRequest(
+      taxonEntriesDecoder,
       {
         useCache: true,
         method: 'get',
@@ -56,7 +57,7 @@ export interface OrthoService extends WdkService {
   getGenomeSources: () => Promise<unknown>;
   getGenomeStatistics: () => Promise<unknown>;
   getGroupLayout: (groupName: string) => Promise<GroupLayout>;
-  getTaxons: () => Promise<unknown>;
+  getTaxons: () => Promise<TaxonEntries>;
 }
 
 export function isOrthoService(wdkService: WdkService): wdkService is OrthoService {

--- a/Site/webapp/wdkCustomization/js/client/utils/clusterGraph.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/clusterGraph.ts
@@ -1,0 +1,10 @@
+export type EdgeType = 'O' | 'C' | 'P' | 'L' | 'M' | 'N';
+
+export const edgeTypeDisplayNames: Record<EdgeType, string> = {
+  'O': 'Ortholog',
+  'C': 'Coortholog',
+  'P': 'Inparalog',
+  'L': 'PeripheralCore',
+  'M': 'PeripheralPeripheral',
+  'N': 'Normal'
+};

--- a/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
@@ -1,10 +1,11 @@
 import * as Decode from 'wdk-client/Utils/Json';
 
+import { EdgeType } from './clusterGraph';
 import { TaxonEntries, TaxonEntry, taxonEntryDecoder, taxonEntriesDecoder} from './taxons';
 
 export interface GroupLayout {
-  edges: Record<string, EdgeEntry>;
-  nodes: Record<string, NodeEntry>;
+  edges: EdgeEntries;
+  nodes: NodeEntries;
   group: GroupField;
   minEvalueExp: number;
   maxEvalueExp: number;
@@ -13,17 +14,19 @@ export interface GroupLayout {
   taxons: TaxonEntries;
 }
 
+export type EdgeEntries = Record<string, EdgeEntry>;
+
 export interface EdgeEntry {
   E: string;
   Q: number;
   S: number;
-  T: unknown;
+  T: EdgeType;
   queryId: string;
   score: number;
   subjectId: string;
 }
 
-export type EdgeType = 'O' | 'C' | 'P' | 'L' | 'M' | 'N';
+export type NodeEntries = Record<string, NodeEntry>;
 
 export interface NodeEntry {
   x: string;
@@ -81,7 +84,7 @@ export const edgeEntryDecoder: Decode.Decoder<EdgeEntry> = Decode.combine(
   Decode.field('subjectId', Decode.string)
 );
 
-
+export const edgeEntriesDecoder: Decode.Decoder<EdgeEntries> = Decode.objectOf(edgeEntryDecoder);
 
 export const nodeEntryDecoder: Decode.Decoder<NodeEntry> = Decode.combine(
   Decode.field('x', Decode.string),
@@ -89,6 +92,8 @@ export const nodeEntryDecoder: Decode.Decoder<NodeEntry> = Decode.combine(
   Decode.field('i', Decode.number),
   Decode.field('id', Decode.string)
 );
+
+export const nodeEntriesDecoder: Decode.Decoder<NodeEntries> = Decode.objectOf(nodeEntryDecoder);
 
 export const ecNumberEntryDecoder: Decode.Decoder<EcNumberEntry> = Decode.combine(
   Decode.field('code', Decode.string),
@@ -121,8 +126,8 @@ export const groupFieldDecoder: Decode.Decoder<GroupField> = Decode.combine(
 );
 
 export const groupLayoutDecoder: Decode.Decoder<GroupLayout> = Decode.combine(
-  Decode.field('edges', Decode.ok),
-  Decode.field('nodes', Decode.objectOf(nodeEntryDecoder)),
+  Decode.field('edges', edgeEntriesDecoder),
+  Decode.field('nodes', nodeEntriesDecoder),
   Decode.field('group', groupFieldDecoder),
   Decode.field('minEvalueExp', Decode.number),
   Decode.field('maxEvalueExp', Decode.number),

--- a/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
@@ -1,5 +1,7 @@
 import * as Decode from 'wdk-client/Utils/Json';
 
+import { TaxonEntries, taxonEntriesDecoder } from './taxons';
+
 export interface GroupLayout {
   edges: unknown;
   nodes: unknown;
@@ -8,7 +10,7 @@ export interface GroupLayout {
   maxEValueExp: number;
   size: number;
   taxonCounts: Record<string, number>;
-  taxons: unknown;
+  taxons: TaxonEntries;
 }
 
 export const groupLayoutDecoder: Decode.Decoder<GroupLayout> = Decode.combine(
@@ -19,5 +21,5 @@ export const groupLayoutDecoder: Decode.Decoder<GroupLayout> = Decode.combine(
   Decode.field('maxEValueExp', Decode.number),
   Decode.field('size', Decode.number),
   Decode.field('taxonCounts', Decode.objectOf(Decode.number)),
-  Decode.field('taxons', Decode.ok)
+  Decode.field('taxons', taxonEntriesDecoder)
 );

--- a/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
@@ -1,5 +1,13 @@
-import * as Decode from 'wdk-client/Utils/Json';
-
+import {
+  Decoder,
+  arrayOf,
+  constant,
+  number,
+  objectOf,
+  oneOf,
+  record,
+  string
+} from 'wdk-client/Utils/Json';
 import { EdgeType } from './clusterGraph';
 import { TaxonEntries, TaxonEntry, taxonEntryDecoder, taxonEntriesDecoder} from './taxons';
 
@@ -65,73 +73,73 @@ export interface PfamDomainEntry {
   symbol: string;
 }
 
-export const edgeTypeDecoder: Decode.Decoder<EdgeType> = Decode.oneOf(
-  Decode.constant('O'),
-  Decode.constant('C'),
-  Decode.constant('P'),
-  Decode.constant('L'),
-  Decode.constant('M'),
-  Decode.constant('N')
+export const edgeTypeDecoder: Decoder<EdgeType> = oneOf(
+  constant('O'),
+  constant('C'),
+  constant('P'),
+  constant('L'),
+  constant('M'),
+  constant('N')
 );
 
-export const edgeEntryDecoder: Decode.Decoder<EdgeEntry> = Decode.combine(
-  Decode.field('E', Decode.string),
-  Decode.field('Q', Decode.number),
-  Decode.field('S', Decode.number),
-  Decode.field('T', edgeTypeDecoder),
-  Decode.field('queryId', Decode.string),
-  Decode.field('score', Decode.number),
-  Decode.field('subjectId', Decode.string)
-);
+export const edgeEntryDecoder: Decoder<EdgeEntry> = record({
+  E: string,
+  Q: number,
+  S: number,
+  T: edgeTypeDecoder,
+  queryId: string,
+  score: number,
+  subjectId: string
+});
 
-export const edgeEntriesDecoder: Decode.Decoder<EdgeEntries> = Decode.objectOf(edgeEntryDecoder);
+export const edgeEntriesDecoder: Decoder<EdgeEntries> = objectOf(edgeEntryDecoder);
 
-export const nodeEntryDecoder: Decode.Decoder<NodeEntry> = Decode.combine(
-  Decode.field('x', Decode.string),
-  Decode.field('y', Decode.string),
-  Decode.field('i', Decode.number),
-  Decode.field('id', Decode.string)
-);
+export const nodeEntryDecoder: Decoder<NodeEntry> = record({
+  x: string,
+  y: string,
+  i: number,
+  id: string
+});
 
-export const nodeEntriesDecoder: Decode.Decoder<NodeEntries> = Decode.objectOf(nodeEntryDecoder);
+export const nodeEntriesDecoder: Decoder<NodeEntries> = objectOf(nodeEntryDecoder);
 
-export const ecNumberEntryDecoder: Decode.Decoder<EcNumberEntry> = Decode.combine(
-  Decode.field('code', Decode.string),
-  Decode.field('color', Decode.string),
-  Decode.field('count', Decode.number),
-  Decode.field('index', Decode.number)
-);
+export const ecNumberEntryDecoder: Decoder<EcNumberEntry> = record({
+  code: string,
+  color: string,
+  count: number,
+  index: number
+});
 
-export const geneEntryDecoder: Decode.Decoder<GeneEntry> = Decode.combine(
-  Decode.field('description', Decode.string),
-  Decode.field('ecNumbers', Decode.arrayOf(Decode.string)),
-  Decode.field('length', Decode.number),
-  Decode.field('pfamDomains', Decode.objectOf(Decode.arrayOf(Decode.number))),
-  Decode.field('taxon', taxonEntryDecoder)
-);
+export const geneEntryDecoder: Decoder<GeneEntry> = record({
+  description: string,
+  ecNumbers: arrayOf(string),
+  length: number,
+  pfamDomains: objectOf(arrayOf(number)),
+  taxon: taxonEntryDecoder
+});
 
-export const pfamDomainEntryDecoder: Decode.Decoder<PfamDomainEntry> = Decode.combine(
-  Decode.field('accession', Decode.string),
-  Decode.field('color', Decode.string),
-  Decode.field('count', Decode.number),
-  Decode.field('description', Decode.string),
-  Decode.field('index', Decode.number),
-  Decode.field('symbol', Decode.string)
-);
+export const pfamDomainEntryDecoder: Decoder<PfamDomainEntry> = record({
+  accession: string,
+  color: string,
+  count: number,
+  description: string,
+  index: number,
+  symbol: string
+});
 
-export const groupFieldDecoder: Decode.Decoder<GroupField> = Decode.combine(
-  Decode.field('ecNumbers', Decode.objectOf(ecNumberEntryDecoder)),
-  Decode.field('genes', Decode.objectOf(geneEntryDecoder)),
-  Decode.field('pfamDomains', Decode.objectOf(pfamDomainEntryDecoder))
-);
+export const groupFieldDecoder: Decoder<GroupField> = record({
+  ecNumbers: objectOf(ecNumberEntryDecoder),
+  genes: objectOf(geneEntryDecoder),
+  pfamDomains: objectOf(pfamDomainEntryDecoder)
+});
 
-export const groupLayoutDecoder: Decode.Decoder<GroupLayout> = Decode.combine(
-  Decode.field('edges', edgeEntriesDecoder),
-  Decode.field('nodes', nodeEntriesDecoder),
-  Decode.field('group', groupFieldDecoder),
-  Decode.field('minEvalueExp', Decode.number),
-  Decode.field('maxEvalueExp', Decode.number),
-  Decode.field('size', Decode.number),
-  Decode.field('taxonCounts', Decode.objectOf(Decode.number)),
-  Decode.field('taxons', taxonEntriesDecoder)
-);
+export const groupLayoutDecoder: Decoder<GroupLayout> = record({
+  edges: edgeEntriesDecoder,
+  nodes: nodeEntriesDecoder,
+  group: groupFieldDecoder,
+  minEvalueExp: number,
+  maxEvalueExp: number,
+  size: number,
+  taxonCounts: objectOf(number),
+  taxons: taxonEntriesDecoder
+});

--- a/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
@@ -1,11 +1,11 @@
 import * as Decode from 'wdk-client/Utils/Json';
 
-import { TaxonEntries, taxonEntriesDecoder } from './taxons';
+import { TaxonEntries, TaxonEntry, taxonEntryDecoder, taxonEntriesDecoder} from './taxons';
 
 export interface GroupLayout {
   edges: unknown;
   nodes: unknown;
-  group: unknown;
+  group: GroupField;
   minEvalueExp: number;
   maxEvalueExp: number;
   size: number;
@@ -13,10 +13,70 @@ export interface GroupLayout {
   taxons: TaxonEntries;
 }
 
+export interface GroupField {
+  ecNumbers: Record<string, EcNumberEntry>;
+  genes: Record<string, GeneEntry>;
+  pfamDomains: Record<string, PfamDomainEntry>;
+}
+
+export interface EcNumberEntry {
+  code: string;
+  color: string;
+  count: number;
+  index: number;
+}
+
+export interface GeneEntry {
+  description: string;
+  ecNumbers: string[];
+  length: number;
+  pfamDomains: Record<string, number[]>;
+  taxon: TaxonEntry;
+}
+
+export interface PfamDomainEntry {
+  accession: string;
+  color: string;
+  count: number;
+  description: string;
+  index: number;
+  symbol: string;
+}
+
+export const ecNumberEntryDecoder: Decode.Decoder<EcNumberEntry> = Decode.combine(
+  Decode.field('code', Decode.string),
+  Decode.field('color', Decode.string),
+  Decode.field('count', Decode.number),
+  Decode.field('index', Decode.number)
+);
+
+export const geneEntryDecoder: Decode.Decoder<GeneEntry> = Decode.combine(
+  Decode.field('description', Decode.string),
+  Decode.field('ecNumbers', Decode.arrayOf(Decode.string)),
+  Decode.field('length', Decode.number),
+  Decode.field('pfamDomains', Decode.objectOf(Decode.arrayOf(Decode.number))),
+  Decode.field('taxon', taxonEntryDecoder)
+);
+
+export const pfamDomainEntryDecoder: Decode.Decoder<PfamDomainEntry> = Decode.combine(
+  Decode.field('accession', Decode.string),
+  Decode.field('color', Decode.string),
+  Decode.field('count', Decode.number),
+  Decode.field('description', Decode.string),
+  Decode.field('index', Decode.number),
+  Decode.field('symbol', Decode.string)
+);
+
+export const groupFieldDecoder: Decode.Decoder<GroupField> = Decode.combine(
+  Decode.field('ecNumbers', Decode.objectOf(ecNumberEntryDecoder)),
+  Decode.field('genes', Decode.objectOf(geneEntryDecoder)),
+  Decode.field('pfamDomains', Decode.objectOf(pfamDomainEntryDecoder))
+);
+
 export const groupLayoutDecoder: Decode.Decoder<GroupLayout> = Decode.combine(
   Decode.field('edges', Decode.ok),
   Decode.field('nodes', Decode.ok),
-  Decode.field('group', Decode.ok),
+  Decode.field('group', groupFieldDecoder),
   Decode.field('minEvalueExp', Decode.number),
   Decode.field('maxEvalueExp', Decode.number),
   Decode.field('size', Decode.number),

--- a/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
@@ -4,9 +4,9 @@ export interface GroupLayout {
   edges: unknown;
   nodes: unknown;
   group: unknown;
-  minEValueExp: unknown;
-  maxEValueExp: unknown;
-  size: unknown;
+  minEValueExp: number;
+  maxEValueExp: number;
+  size: number;
   taxonCounts: unknown;
   taxons: unknown;
 }
@@ -15,9 +15,9 @@ export const groupLayoutDecoder: Decode.Decoder<GroupLayout> = Decode.combine(
   Decode.field('edges', Decode.ok),
   Decode.field('nodes', Decode.ok),
   Decode.field('group', Decode.ok),
-  Decode.field('minEValueExp', Decode.ok),
-  Decode.field('maxEValueExp', Decode.ok),
-  Decode.field('size', Decode.ok),
+  Decode.field('minEValueExp', Decode.number),
+  Decode.field('maxEValueExp', Decode.number),
+  Decode.field('size', Decode.number),
   Decode.field('taxonCounts', Decode.ok),
   Decode.field('taxons', Decode.ok)
 );

--- a/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
@@ -7,7 +7,7 @@ export interface GroupLayout {
   minEValueExp: number;
   maxEValueExp: number;
   size: number;
-  taxonCounts: unknown;
+  taxonCounts: Record<string, number>;
   taxons: unknown;
 }
 
@@ -18,6 +18,6 @@ export const groupLayoutDecoder: Decode.Decoder<GroupLayout> = Decode.combine(
   Decode.field('minEValueExp', Decode.number),
   Decode.field('maxEValueExp', Decode.number),
   Decode.field('size', Decode.number),
-  Decode.field('taxonCounts', Decode.ok),
+  Decode.field('taxonCounts', Decode.objectOf(Decode.number)),
   Decode.field('taxons', Decode.ok)
 );

--- a/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
@@ -3,7 +3,7 @@ import * as Decode from 'wdk-client/Utils/Json';
 import { TaxonEntries, TaxonEntry, taxonEntryDecoder, taxonEntriesDecoder} from './taxons';
 
 export interface GroupLayout {
-  edges: unknown;
+  edges: Record<string, EdgeEntry>;
   nodes: Record<string, NodeEntry>;
   group: GroupField;
   minEvalueExp: number;
@@ -12,6 +12,18 @@ export interface GroupLayout {
   taxonCounts: Record<string, number>;
   taxons: TaxonEntries;
 }
+
+export interface EdgeEntry {
+  E: string;
+  Q: number;
+  S: number;
+  T: unknown;
+  queryId: string;
+  score: number;
+  subjectId: string;
+}
+
+export type EdgeType = 'O' | 'C' | 'P' | 'L' | 'M' | 'N';
 
 export interface NodeEntry {
   x: string;
@@ -49,6 +61,27 @@ export interface PfamDomainEntry {
   index: number;
   symbol: string;
 }
+
+export const edgeTypeDecoder: Decode.Decoder<EdgeType> = Decode.oneOf(
+  Decode.constant('O'),
+  Decode.constant('C'),
+  Decode.constant('P'),
+  Decode.constant('L'),
+  Decode.constant('M'),
+  Decode.constant('N')
+);
+
+export const edgeEntryDecoder: Decode.Decoder<EdgeEntry> = Decode.combine(
+  Decode.field('E', Decode.string),
+  Decode.field('Q', Decode.number),
+  Decode.field('S', Decode.number),
+  Decode.field('T', edgeTypeDecoder),
+  Decode.field('queryId', Decode.string),
+  Decode.field('score', Decode.number),
+  Decode.field('subjectId', Decode.string)
+);
+
+
 
 export const nodeEntryDecoder: Decode.Decoder<NodeEntry> = Decode.combine(
   Decode.field('x', Decode.string),

--- a/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
@@ -6,8 +6,8 @@ export interface GroupLayout {
   edges: unknown;
   nodes: unknown;
   group: unknown;
-  minEValueExp: number;
-  maxEValueExp: number;
+  minEvalueExp: number;
+  maxEvalueExp: number;
   size: number;
   taxonCounts: Record<string, number>;
   taxons: TaxonEntries;
@@ -17,8 +17,8 @@ export const groupLayoutDecoder: Decode.Decoder<GroupLayout> = Decode.combine(
   Decode.field('edges', Decode.ok),
   Decode.field('nodes', Decode.ok),
   Decode.field('group', Decode.ok),
-  Decode.field('minEValueExp', Decode.number),
-  Decode.field('maxEValueExp', Decode.number),
+  Decode.field('minEvalueExp', Decode.number),
+  Decode.field('maxEvalueExp', Decode.number),
   Decode.field('size', Decode.number),
   Decode.field('taxonCounts', Decode.objectOf(Decode.number)),
   Decode.field('taxons', taxonEntriesDecoder)

--- a/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
@@ -1,0 +1,23 @@
+import * as Decode from 'wdk-client/Utils/Json';
+
+export interface GroupLayout {
+  edges: unknown;
+  nodes: unknown;
+  group: unknown;
+  minEValueExp: unknown;
+  maxEValueExp: unknown;
+  size: unknown;
+  taxonCounts: unknown;
+  taxons: unknown;
+}
+
+export const groupLayoutDecoder: Decode.Decoder<GroupLayout> = Decode.combine(
+  Decode.field('edges', Decode.ok),
+  Decode.field('nodes', Decode.ok),
+  Decode.field('group', Decode.ok),
+  Decode.field('minEValueExp', Decode.ok),
+  Decode.field('maxEValueExp', Decode.ok),
+  Decode.field('size', Decode.ok),
+  Decode.field('taxonCounts', Decode.ok),
+  Decode.field('taxons', Decode.ok)
+);

--- a/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
@@ -4,13 +4,20 @@ import { TaxonEntries, TaxonEntry, taxonEntryDecoder, taxonEntriesDecoder} from 
 
 export interface GroupLayout {
   edges: unknown;
-  nodes: unknown;
+  nodes: Record<string, NodeEntry>;
   group: GroupField;
   minEvalueExp: number;
   maxEvalueExp: number;
   size: number;
   taxonCounts: Record<string, number>;
   taxons: TaxonEntries;
+}
+
+export interface NodeEntry {
+  x: string;
+  y: string;
+  i: number;
+  id: string;
 }
 
 export interface GroupField {
@@ -42,6 +49,13 @@ export interface PfamDomainEntry {
   index: number;
   symbol: string;
 }
+
+export const nodeEntryDecoder: Decode.Decoder<NodeEntry> = Decode.combine(
+  Decode.field('x', Decode.string),
+  Decode.field('y', Decode.string),
+  Decode.field('i', Decode.number),
+  Decode.field('id', Decode.string)
+);
 
 export const ecNumberEntryDecoder: Decode.Decoder<EcNumberEntry> = Decode.combine(
   Decode.field('code', Decode.string),
@@ -75,7 +89,7 @@ export const groupFieldDecoder: Decode.Decoder<GroupField> = Decode.combine(
 
 export const groupLayoutDecoder: Decode.Decoder<GroupLayout> = Decode.combine(
   Decode.field('edges', Decode.ok),
-  Decode.field('nodes', Decode.ok),
+  Decode.field('nodes', Decode.objectOf(nodeEntryDecoder)),
   Decode.field('group', groupFieldDecoder),
   Decode.field('minEvalueExp', Decode.number),
   Decode.field('maxEvalueExp', Decode.number),

--- a/Site/webapp/wdkCustomization/js/client/utils/taxons.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/taxons.ts
@@ -1,4 +1,12 @@
-import * as Decode from 'wdk-client/Utils/Json';
+import {
+  Decoder,
+  boolean,
+  lazy,
+  number,
+  objectOf,
+  record,
+  string
+} from 'wdk-client/Utils/Json';
 
 export interface TaxonEntry {
   abbrev: string;
@@ -12,14 +20,14 @@ export interface TaxonEntry {
 
 export type TaxonEntries = Record<string, TaxonEntry>;
 
-export const taxonEntryDecoder: Decode.Decoder<TaxonEntry> = Decode.combine(
-  Decode.field('abbrev', Decode.string),
-  Decode.field('children', Decode.lazy(() => Decode.objectOf(taxonEntryDecoder))),
-  Decode.field('commonName', Decode.string),
-  Decode.field('id', Decode.number),
-  Decode.field('name', Decode.string),
-  Decode.field('sortIndex', Decode.number),
-  Decode.field('species', Decode.boolean)
-);
+export const taxonEntryDecoder: Decoder<TaxonEntry> = record({
+  abbrev: string,
+  children: lazy(() => objectOf(taxonEntryDecoder)),
+  commonName: string,
+  id: number,
+  name: string,
+  sortIndex: number,
+  species: boolean
+});
 
-export const taxonEntriesDecoder: Decode.Decoder<TaxonEntries> = Decode.objectOf(taxonEntryDecoder);
+export const taxonEntriesDecoder: Decoder<TaxonEntries> = objectOf(taxonEntryDecoder);

--- a/Site/webapp/wdkCustomization/js/client/utils/taxons.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/taxons.ts
@@ -1,0 +1,25 @@
+import * as Decode from 'wdk-client/Utils/Json';
+
+export interface TaxonEntry {
+  abbrev: string;
+  children: Record<string, TaxonEntry>;
+  commonName: string;
+  id: number;
+  name: string;
+  sortIndex: number;
+  species: boolean;
+}
+
+export type TaxonEntries = Record<string, TaxonEntry>;
+
+export const taxonEntryDecoder: Decode.Decoder<TaxonEntry> = Decode.combine(
+  Decode.field('abbrev', Decode.string),
+  Decode.field('children', Decode.lazy(() => Decode.objectOf(taxonEntryDecoder))),
+  Decode.field('commonName', Decode.string),
+  Decode.field('id', Decode.number),
+  Decode.field('name', Decode.string),
+  Decode.field('sortIndex', Decode.number),
+  Decode.field('species', Decode.boolean)
+);
+
+export const taxonEntriesDecoder: Decode.Decoder<TaxonEntries> = Decode.objectOf(taxonEntryDecoder);


### PR DESCRIPTION
This PR...

* Implements a  `useOrthoService` hook
* Sets up the boilerplate for the 4 OrthoMCL-specific services
* Implements a decoder for the "group layout" service, which serves all the data needed to render an ortholog group's cluster graph
* Sets up a test route for rendering a cluster graph

Depends on https://github.com/VEuPathDB/WDKClient/pull/28 and https://github.com/VEuPathDB/OrthoMCLService/pull/1