### PR TITLE
Introduce "ortho-client" alias

### DIFF
--- a/Site/tsconfig.json
+++ b/Site/tsconfig.json
@@ -4,6 +4,7 @@
     "paths": {
       "wdk-client/*": [ "WDKClient/Client/src/*" ],
       "ebrc-client/*": [ "EbrcWebsiteCommon/Site/webapp/wdkCustomization/js/client/*" ],
+      "ortho-client/*": [ "OrthoMCLClient/Site/webapp/wdkCustomization/js/client/*" ],
       "*": [
         "WDKClient/Client/node_modules/*",
         "WDKClient/Client/node_modules/@types/*",

--- a/Site/webpack.config.js
+++ b/Site/webpack.config.js
@@ -3,5 +3,10 @@ var configure = require('../../EbrcWebsiteCommon/Site/site.webpack.config');
 module.exports = configure({
   entry: {
     'site-client': __dirname + '/webapp/wdkCustomization/js/client/main.js'
+  },
+  resolve: {
+    alias: {
+      'ortho-client': __dirname + '/webapp/wdkCustomization/js/client'
+    }
   }
 });


### PR DESCRIPTION
This PR provides a TypeScript path + Webpack alias "ortho-client" so that various `OrthoMCLClient` modules can be imported via absolute paths.