### PR TITLE
Cleanup: use absolute paths for most imports

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 
-import { OrthoMCLPage } from './components/layout/OrthoMCLPage';
+import { OrthoMCLPage } from 'ortho-client/components/layout/OrthoMCLPage';
 import {
   RecordTable as GroupRecordTable,
   RecordAttributeSection as GroupRecordAttributeSection
-} from './records/GroupRecordClasses.GroupRecordClass';
+} from 'ortho-client/records/GroupRecordClasses.GroupRecordClass';
 import {
   RecordTable as SequenceRecordTable
-} from './records/SequenceRecordClasses.SequenceRecordClass';
+} from 'ortho-client/records/SequenceRecordClasses.SequenceRecordClass';
 import {
   RecordAttributeSectionProps,
   RecordTableProps
-} from './records/Types';
+} from 'ortho-client/records/Types';
 
 export default {
   Page: () => OrthoMCLPage,

--- a/Site/webapp/wdkCustomization/js/client/components/cluster-graph/ClusterGraphCanvas.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/cluster-graph/ClusterGraphCanvas.tsx
@@ -4,7 +4,7 @@ import { Core } from 'cytoscape';
 import produce from 'immer';
 import CytoscapeComponent from 'react-cytoscapejs';
 
-import { useCytoscapeConfig } from '../../hooks/cytoscapeData';
+import { useCytoscapeConfig } from 'ortho-client/hooks/cytoscapeData';
 import {
   useEdgeMouseMovementEventHandlers,
   useNodeClickEventHandler,

--- a/Site/webapp/wdkCustomization/js/client/components/cluster-graph/ClusterGraphDisplay.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/cluster-graph/ClusterGraphDisplay.tsx
@@ -14,21 +14,21 @@ import {
   initialEdgeTypeSelections,
   nodeDisplayTypeOrder,
   nodeDisplayTypeDisplayNames
-} from '../../utils/clusterGraph';
+} from 'ortho-client/utils/clusterGraph';
 import {
   GraphInformationTabKey,
   GraphInformationTabProps,
   graphInformationBaseTabConfigs
-} from '../../utils/graphInformation';
-import { GroupLayout } from '../../utils/groupLayout';
-import { TaxonUiMetadata } from '../../utils/taxons';
+} from 'ortho-client/utils/graphInformation';
+import { GroupLayout } from 'ortho-client/utils/groupLayout';
+import { TaxonUiMetadata } from 'ortho-client/utils/taxons';
 
-import { ClusterGraphCanvas } from './ClusterGraphCanvas';
-import { GraphControls } from './GraphControls';
-import { GraphInformation } from './GraphInformation';
-import { Instructions } from './Instructions';
-import { NodeDetails } from './NodeDetails';
-import { SequenceList } from './SequenceList';
+import { ClusterGraphCanvas } from 'ortho-client/components/cluster-graph/ClusterGraphCanvas';
+import { GraphControls } from 'ortho-client/components/cluster-graph/GraphControls';
+import { GraphInformation } from 'ortho-client/components/cluster-graph/GraphInformation';
+import { Instructions } from 'ortho-client/components/cluster-graph/Instructions';
+import { NodeDetails } from 'ortho-client/components/cluster-graph/NodeDetails';
+import { SequenceList } from 'ortho-client/components/cluster-graph/SequenceList';
 
 import './ClusterGraphDisplay.scss';
 

--- a/Site/webapp/wdkCustomization/js/client/components/cluster-graph/GraphControls.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/cluster-graph/GraphControls.tsx
@@ -2,9 +2,9 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { Checkbox, RadioList, SliderInput, TextBox, Tooltip } from 'wdk-client/Components';
 
-import { EdgeTypeOption, NodeDisplayType } from '../../utils/clusterGraph';
+import { EdgeTypeOption, NodeDisplayType } from 'ortho-client/utils/clusterGraph';
 
-import { GraphAccordion } from './GraphAccordion';
+import { GraphAccordion } from 'ortho-client/components/cluster-graph/GraphAccordion';
 
 import './GraphControls.scss';
 

--- a/Site/webapp/wdkCustomization/js/client/components/cluster-graph/GraphInformation.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/cluster-graph/GraphInformation.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Tabs } from 'wdk-client/Components';
 import { TabConfig } from 'wdk-client/Components/Tabs/Tabs';
 
-import { GraphInformationTabKey } from '../../utils/graphInformation';
+import { GraphInformationTabKey } from 'ortho-client/utils/graphInformation';
 
 import './GraphInformation.scss';
 

--- a/Site/webapp/wdkCustomization/js/client/components/cluster-graph/GraphInformationDataTable.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/cluster-graph/GraphInformationDataTable.tsx
@@ -5,7 +5,11 @@ import { orderBy } from 'lodash';
 import { RealTimeSearchBox } from 'wdk-client/Components';
 import { Mesa, MesaState } from 'wdk-client/Components/Mesa';
 
-import { GraphInformationColumnKey, GraphInformationColumns, GraphInformationSortObject } from '../../utils/graphInformation';
+import {
+  GraphInformationColumnKey,
+  GraphInformationColumns,
+  GraphInformationSortObject
+} from 'ortho-client/utils/graphInformation';
 
 interface Props<R, C extends GraphInformationColumnKey<R>> {
   rows: R[];

--- a/Site/webapp/wdkCustomization/js/client/components/cluster-graph/Instructions.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/cluster-graph/Instructions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { GraphAccordion } from './GraphAccordion';
+import { GraphAccordion } from 'ortho-client/components/cluster-graph/GraphAccordion';
 
 import './Instructions.scss';
 

--- a/Site/webapp/wdkCustomization/js/client/components/cluster-graph/NodeDetails.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/cluster-graph/NodeDetails.tsx
@@ -13,11 +13,11 @@ import {
   layoutAndAccessionToPfamDomainRows,
   renderEdgeType,
   renderSequenceLink
-} from '../../utils/graphInformation';
-import { GroupLayout } from '../../utils/groupLayout';
+} from 'ortho-client/utils/graphInformation';
+import { GroupLayout } from 'ortho-client/utils/groupLayout';
 
-import { GraphAccordion } from './GraphAccordion';
-import { GraphInformationDataTable } from './GraphInformationDataTable';
+import { GraphAccordion } from 'ortho-client/components/cluster-graph/GraphAccordion';
+import { GraphInformationDataTable } from 'ortho-client/components/cluster-graph/GraphInformationDataTable';
 
 import './NodeDetails.scss';
 

--- a/Site/webapp/wdkCustomization/js/client/components/cluster-graph/SequenceList.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/cluster-graph/SequenceList.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 
-import { GraphInformationDataTable } from './GraphInformationDataTable';
+import { GraphInformationDataTable } from 'ortho-client/components/cluster-graph/GraphInformationDataTable';
 
 import {
   GraphInformationColumns,
@@ -8,7 +8,7 @@ import {
   SequenceListRow,
   layoutToSequenceListRows,
   renderSequenceLink
-} from '../../utils/graphInformation';
+} from 'ortho-client/utils/graphInformation';
 
 export function SequenceList({ layout, setHighlightedSequenceNodeId }: GraphInformationTabProps) {
   const rows = useMemo(

--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -21,7 +21,7 @@ import {
   useSearchTree,
   useSessionBackedSearchTerm,
   useSessionBackedExpandedBranches
-} from '../../hooks/searchCheckboxTree';
+} from 'ortho-client/hooks/searchCheckboxTree';
 
 import './OrthoMCLPage.scss';
 

--- a/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomain.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomain.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 
-import { assignColors } from '../../utils/pfamDomain';
+import { assignColors } from 'ortho-client/utils/pfamDomain';
 
 import './PfamDomain.scss';
 

--- a/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomainArchitecture.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/pfam-domains/PfamDomainArchitecture.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { PfamDomain } from './PfamDomain';
+import { PfamDomain } from 'ortho-client/components/pfam-domains/PfamDomain';
 
 import './PfamDomainArchitecture.scss';
 

--- a/Site/webapp/wdkCustomization/js/client/controllers/GroupClusterGraphController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/GroupClusterGraphController.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 import { Loading } from 'wdk-client/Components';
 
-import { useCorePeripheralMap } from '../hooks/dataSummary';
-import { useOrthoService } from '../hooks/orthoService';
-import { useTaxonUiMetadata } from '../hooks/taxons';
+import { useCorePeripheralMap } from 'ortho-client/hooks/dataSummary';
+import { useOrthoService } from 'ortho-client/hooks/orthoService';
+import { useTaxonUiMetadata } from 'ortho-client/hooks/taxons';
 
-import { ClusterGraphDisplay } from '../components/cluster-graph/ClusterGraphDisplay';
+import { ClusterGraphDisplay } from 'ortho-client/components/cluster-graph/ClusterGraphDisplay';
 
 interface Props {
   groupName: string;

--- a/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/OrthoMCLHomePageController.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useLayoutEffect } from 'react';
+import React, { useCallback } from 'react';
 
 import { useSessionBackedState } from 'wdk-client/Hooks/SessionBackedState';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
@@ -8,7 +8,7 @@ import { SearchPane } from 'ebrc-client/components/homepage/SearchPane';
 import { WorkshopExercises } from 'ebrc-client/components/homepage/WorkshopExercises';
 import { NewsPane } from 'ebrc-client/components/homepage/NewsPane';
 
-import { useSearchTree } from '../hooks/searchCheckboxTree';
+import { useSearchTree } from 'ortho-client/hooks/searchCheckboxTree';
 
 const IS_NEWS_EXPANDED_SESSION_KEY = 'homepage-is-news-expanded';
 

--- a/Site/webapp/wdkCustomization/js/client/hooks/cytoscapeData.ts
+++ b/Site/webapp/wdkCustomization/js/client/hooks/cytoscapeData.ts
@@ -11,18 +11,18 @@ import { noop, orderBy } from 'lodash';
 import {
   NodeDisplayType,
   ProteinType
-} from '../utils/clusterGraph';
+} from 'ortho-client/utils/clusterGraph';
 import {
   makePieStyles,
   makeEdgeData,
   nodeEntryToCytoscapeData
-} from '../utils/cytoscapeData';
+} from 'ortho-client/utils/cytoscapeData';
 import {
   EcNumberEntry,
   GroupLayout,
   PfamDomainEntry
-} from '../utils/groupLayout';
-import { TaxonUiMetadata } from '../utils/taxons';
+} from 'ortho-client/utils/groupLayout';
+import { TaxonUiMetadata } from 'ortho-client/utils/taxons';
 
 const MAX_PIE_SLICES = 16;
 

--- a/Site/webapp/wdkCustomization/js/client/hooks/cytoscapeEventHandlers.ts
+++ b/Site/webapp/wdkCustomization/js/client/hooks/cytoscapeEventHandlers.ts
@@ -11,13 +11,13 @@ import produce from 'immer';
 import {
   CytoscapeConfig,
   useCyEffect
-} from './cytoscapeData';
+} from 'ortho-client/hooks/cytoscapeData';
 import {
   addAndRemoveCytoscapeClasses,
   addCytoscapeClass,
   removeCytoscapeClass,
   removeCytoscapeClasses
-} from '../utils/cytoscapeClasses';
+} from 'ortho-client/utils/cytoscapeClasses';
 
 export function useUpdateHighlightedNodes(
   cytoscapeConfig: CytoscapeConfig,

--- a/Site/webapp/wdkCustomization/js/client/hooks/dataSummary.ts
+++ b/Site/webapp/wdkCustomization/js/client/hooks/dataSummary.ts
@@ -1,9 +1,9 @@
 import { keyBy, mapValues, once } from 'lodash';
 
-import { ProteinType } from '../utils/clusterGraph';
-import { GenomeSourcesRows } from '../utils/dataSummary';
+import { ProteinType } from 'ortho-client/utils/clusterGraph';
+import { GenomeSourcesRows } from 'ortho-client/utils/dataSummary';
 
-import { useOrthoService } from './orthoService';
+import { useOrthoService } from 'ortho-client/hooks/orthoService';
 
 export function useGenomeSourcesRows() {
   return useOrthoService(

--- a/Site/webapp/wdkCustomization/js/client/hooks/orthoService.ts
+++ b/Site/webapp/wdkCustomization/js/client/hooks/orthoService.ts
@@ -1,6 +1,6 @@
 import { ServiceCallback, useWdkService } from 'wdk-client/Hooks/WdkServiceHook';
 
-import { OrthoService, isOrthoService } from '../services';
+import { OrthoService, isOrthoService } from 'ortho-client/services';
 
 type OrthoServiceCallback<T> = ServiceCallback<OrthoService, T>;
 

--- a/Site/webapp/wdkCustomization/js/client/hooks/taxons.ts
+++ b/Site/webapp/wdkCustomization/js/client/hooks/taxons.ts
@@ -5,7 +5,7 @@ import {
   TaxonUiMetadata,
   makeTaxonTree,
   makeTaxonUiMetadata,
-} from '../utils/taxons';
+} from 'ortho-client/utils/taxons';
 
 import { useOrthoService } from './orthoService';
 

--- a/Site/webapp/wdkCustomization/js/client/main.js
+++ b/Site/webapp/wdkCustomization/js/client/main.js
@@ -1,10 +1,10 @@
 import { initialize } from 'ebrc-client/bootstrap';
-import componentWrappers from './component-wrappers';
-import { wrapRoutes } from './routes';
-import { wrapWdkService } from './services';
+import componentWrappers from 'ortho-client/component-wrappers';
+import { wrapRoutes } from 'ortho-client/routes';
+import { wrapWdkService } from 'ortho-client/services';
 
 import 'eupathdb/wdkCustomization/css/client.scss';
-import '../../css/client.scss';
+import 'site/wdkCustomization/css/client.scss';
 
 initialize({
   componentWrappers,

--- a/Site/webapp/wdkCustomization/js/client/routes.tsx
+++ b/Site/webapp/wdkCustomization/js/client/routes.tsx
@@ -4,8 +4,8 @@ import { RouteComponentProps } from 'react-router';
 
 import { RouteEntry } from 'wdk-client/Core/RouteEntry';
 
-import { OrthoMCLHomePageController } from './controllers/OrthoMCLHomePageController';
-import { GroupClusterGraphController } from './controllers/GroupClusterGraphController';
+import { OrthoMCLHomePageController } from 'ortho-client/controllers/OrthoMCLHomePageController';
+import { GroupClusterGraphController } from 'ortho-client/controllers/GroupClusterGraphController';
 
 export function wrapRoutes(ebrcRoutes: RouteEntry[]): RouteEntry[] {
   return [

--- a/Site/webapp/wdkCustomization/js/client/services.tsx
+++ b/Site/webapp/wdkCustomization/js/client/services.tsx
@@ -5,9 +5,9 @@ import {
   GenomeStatisticsRows,
   genomeSourcesRowsDecoder,
   genomeStatisticsRowsDecoder
-} from './utils/dataSummary';
-import { GroupLayout, groupLayoutDecoder } from './utils/groupLayout';
-import { TaxonEntries, taxonEntriesDecoder } from './utils/taxons';
+} from 'ortho-client/utils/dataSummary';
+import { GroupLayout, groupLayoutDecoder } from 'ortho-client/utils/groupLayout';
+import { TaxonEntries, taxonEntriesDecoder } from 'ortho-client/utils/taxons';
 
 export function wrapWdkService(wdkService: WdkService): OrthoService {
   return ({

--- a/Site/webapp/wdkCustomization/js/client/utils/cytoscapeData.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/cytoscapeData.ts
@@ -5,15 +5,15 @@ import {
   ProteinType,
   corePeripheralLegendColors,
   edgeTypeDisplayNames
-} from '../utils/clusterGraph';
+} from 'ortho-client/utils/clusterGraph';
 import {
   EcNumberEntry,
   EdgeEntry,
   GroupLayout,
   NodeEntry,
   PfamDomainEntry
-} from '../utils/groupLayout';
-import { TaxonUiMetadata } from '../utils/taxons';
+} from 'ortho-client/utils/groupLayout';
+import { TaxonUiMetadata } from 'ortho-client/utils/taxons';
 
 interface NodeData {
   id: string;

--- a/Site/webapp/wdkCustomization/js/client/utils/dataSummary.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/dataSummary.ts
@@ -8,7 +8,7 @@ import {
   string
 } from 'wdk-client/Utils/Json';
 
-import { ProteinType } from './clusterGraph';
+import { ProteinType } from 'ortho-client/utils/clusterGraph';
 
 export interface GenomeSourcesRow {
   core_peripheral: ProteinType;

--- a/Site/webapp/wdkCustomization/js/client/utils/graphInformation.tsx
+++ b/Site/webapp/wdkCustomization/js/client/utils/graphInformation.tsx
@@ -4,8 +4,8 @@ import { Link } from 'wdk-client/Components';
 import { TabConfig } from 'wdk-client/Components/Tabs/Tabs';
 import { MesaColumn, MesaSortObject } from 'wdk-client/Core/CommonTypes';
 
-import { EdgeType, edgeTypeDisplayNames } from './clusterGraph';
-import { GroupLayout } from './groupLayout';
+import { EdgeType, edgeTypeDisplayNames } from 'ortho-client/utils/clusterGraph';
+import { GroupLayout } from 'ortho-client/utils/groupLayout';
 
 export interface GraphInformationTabProps {
   layout: GroupLayout;

--- a/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
@@ -8,8 +8,13 @@ import {
   record,
   string
 } from 'wdk-client/Utils/Json';
-import { EdgeType } from './clusterGraph';
-import { TaxonEntries, TaxonEntry, taxonEntryDecoder, taxonEntriesDecoder } from './taxons';
+import { EdgeType } from 'ortho-client/utils/clusterGraph';
+import {
+  TaxonEntries,
+  TaxonEntry,
+  taxonEntryDecoder,
+  taxonEntriesDecoder
+} from 'ortho-client/utils/taxons';
 
 export interface GroupLayout {
   edges: EdgeEntries;


### PR DESCRIPTION
This PR replaces the majority of relative path imports with absolute path imports.

As a matter of convenience, React components continue to import colocated Sass with a relative path.