### PR TITLE
Groups By Phyletic Pattern search

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/main.js
+++ b/Site/webapp/wdkCustomization/js/client/main.js
@@ -1,5 +1,6 @@
 import { initialize } from 'ebrc-client/bootstrap';
 import componentWrappers from 'ortho-client/component-wrappers';
+import pluginConfig from 'ortho-client/pluginConfig';
 import { wrapRoutes } from 'ortho-client/routes';
 import { wrapWdkService } from 'ortho-client/services';
 
@@ -8,6 +9,7 @@ import 'site/wdkCustomization/css/client.scss';
 
 initialize({
   componentWrappers,
+  pluginConfig,
   wrapRoutes,
   wrapWdkService
 });

--- a/Site/webapp/wdkCustomization/js/client/pluginConfig.ts
+++ b/Site/webapp/wdkCustomization/js/client/pluginConfig.ts
@@ -1,0 +1,13 @@
+import { ClientPluginRegistryEntry } from 'wdk-client/Utils/ClientPlugin';
+
+import { GroupsByPhyleticPattern } from '../questions/GroupsByPhyleticPattern';
+
+const orthoPluginConfig: ClientPluginRegistryEntry<any>[] = [
+  {
+    type: 'questionForm',
+    searchName: 'GroupsByPhyleticPattern',
+    component: GroupsByPhyleticPattern
+  }
+];
+
+export default orthoPluginConfig;

--- a/Site/webapp/wdkCustomization/js/client/pluginConfig.ts
+++ b/Site/webapp/wdkCustomization/js/client/pluginConfig.ts
@@ -1,12 +1,12 @@
 import { ClientPluginRegistryEntry } from 'wdk-client/Utils/ClientPlugin';
 
-import { GroupsByPhyleticPattern } from '../questions/GroupsByPhyleticPattern';
+import { Form as GroupsByPhyleticPatternForm } from '../questions/GroupsByPhyleticPattern/Form';
 
 const orthoPluginConfig: ClientPluginRegistryEntry<any>[] = [
   {
     type: 'questionForm',
     searchName: 'GroupsByPhyleticPattern',
-    component: GroupsByPhyleticPattern
+    component: GroupsByPhyleticPatternForm
   }
 ];
 

--- a/Site/webapp/wdkCustomization/js/client/utils/phyleticPattern.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/phyleticPattern.ts
@@ -1,0 +1,226 @@
+import { groupBy, mapValues, orderBy, partition } from 'lodash';
+
+import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
+import { foldStructure, mapStructure } from 'wdk-client/Utils/TreeUtils';
+
+import { TaxonTree } from 'ortho-client/utils/taxons';
+
+export const cxPhyleticExpression = makeClassNameHelper('PhyleticExpression');
+
+export interface PhyleticExpressionUiTree extends TaxonTree {
+  children: PhyleticExpressionUiTree[];
+  parent?: PhyleticExpressionUiTree;
+  speciesCount: number;
+}
+
+type HomogeneousConstraintState =
+  | 'free'
+  | 'include-at-least-one'
+  | 'include-all'
+  | 'exclude';
+
+export type ConstraintState = HomogeneousConstraintState | 'mixed';
+
+export type ConstraintStates = Record<string, ConstraintState>;
+
+export function getNodeId(node: PhyleticExpressionUiTree) {
+  return node.abbrev;
+}
+
+export function getNodeChildren(node: PhyleticExpressionUiTree) {
+  return node.children;
+}
+
+export function makePhyleticExpressionUiTree(taxonTree: TaxonTree) {
+  const phyleticExpressionUiTree = mapStructure(
+    (node: TaxonTree, mappedChildren: PhyleticExpressionUiTree[]) => ({
+      ...node,
+      children: orderBy(
+        mappedChildren,
+        child => child.species,
+        'desc'
+      ),
+      speciesCount: node.species
+        ? 1
+        : mappedChildren.reduce(
+            (memo, { speciesCount }) => memo + speciesCount,
+            0
+          )
+    }),
+    (node: TaxonTree) => node.children,
+    taxonTree
+  );
+
+  _addParentRefs(phyleticExpressionUiTree, undefined);
+
+  return phyleticExpressionUiTree;
+
+  function _addParentRefs(node: PhyleticExpressionUiTree, parent: PhyleticExpressionUiTree | undefined) {
+    if (parent != null) {
+      node.parent = parent;
+    }
+
+    node.children.forEach(child => {
+      _addParentRefs(child, node);
+    });
+  }
+}
+
+export function makeInitialExpandedNodes(phyleticExpressionUiTree: PhyleticExpressionUiTree) {
+  const initialExpandedNodes = [] as string[];
+
+  _traverse(phyleticExpressionUiTree, 0, 1);
+
+  return initialExpandedNodes;
+
+  function _traverse(node: PhyleticExpressionUiTree, depth: number, maxDepth: number) {
+    if (depth <= maxDepth) {
+      initialExpandedNodes.push(getNodeId(node));
+
+      node.children.forEach(child => {
+        _traverse(child, depth + 1, maxDepth);
+      });
+    }
+  }
+}
+
+export function makeInitialConstraintStates(phyleticExpressionUiTree: PhyleticExpressionUiTree) {
+  return foldStructure(
+    (constraintStates: ConstraintStates, node: PhyleticExpressionUiTree) => {
+      constraintStates[node.abbrev] = 'free';
+      return constraintStates;
+    },
+    {} as ConstraintStates,
+    phyleticExpressionUiTree
+  );
+}
+
+export function getNextConstraintState(currentState: ConstraintState, isSpecies: boolean): HomogeneousConstraintState {
+  if (currentState === 'mixed') {
+    return 'include-all';
+  }
+
+  const stateOrder = isSpecies
+    ? SPECIES_STATE_ORDER
+    : NON_SPECIES_STATE_ORDER;
+
+  const stateIndex = stateOrder.indexOf(currentState);
+
+  return stateOrder[(stateIndex + 1) % stateOrder.length];
+}
+
+const NON_SPECIES_STATE_ORDER = [ 'free', 'include-all', 'include-at-least-one', 'exclude' ] as const;
+const SPECIES_STATE_ORDER = [ 'free', 'include-all', 'exclude' ] as HomogeneousConstraintState[];
+
+export function updateParentConstraintStates(
+  node: PhyleticExpressionUiTree,
+  draftConstraintStates: ConstraintStates,
+  changedState: HomogeneousConstraintState
+): void {
+  const parent = node.parent;
+
+  if (parent != null) {
+    const distinctChildConstraintTypes = new Set(
+      parent.children.map(
+        child => draftConstraintStates[child.abbrev]
+      )
+    );
+
+    if (
+      distinctChildConstraintTypes.size === 1 &&
+      changedState !== 'include-at-least-one'
+    ) {
+      draftConstraintStates[parent.abbrev] = changedState;
+    } else {
+      draftConstraintStates[parent.abbrev] = 'mixed';
+    }
+
+    updateParentConstraintStates(parent, draftConstraintStates, changedState);
+  }
+}
+
+export function updateChildConstraintStates(
+  node: PhyleticExpressionUiTree,
+  draftConstraintStates: ConstraintStates,
+  changedState: HomogeneousConstraintState
+): void {
+  node.children.forEach(child => {
+    if (changedState === 'include-at-least-one') {
+      draftConstraintStates[child.abbrev] = 'free';
+    } else {
+      draftConstraintStates[child.abbrev] = changedState;
+    }
+
+    updateChildConstraintStates(child, draftConstraintStates, changedState);
+  });
+}
+
+export function makePhyleticExpression(
+  phyleticExpressionUiTree: PhyleticExpressionUiTree,
+  constraintStates: ConstraintStates
+) {
+  const nonSpeciesExpressionTerms = [] as string[];
+  const includedSpeciesWithMixedParents = [] as string[];
+  const excludedSpeciesWithMixedParents = [] as string[];
+
+  _traverse(phyleticExpressionUiTree);
+
+  const nonSpeciesSubexpression = nonSpeciesExpressionTerms.length == 0
+    ? undefined
+    : nonSpeciesExpressionTerms.join(' AND ');
+
+  const includedSpeciesSubexpression = includedSpeciesWithMixedParents.length == 0
+    ? undefined
+    : `${includedSpeciesWithMixedParents.join('+')}=${includedSpeciesWithMixedParents.length}T`;
+
+  const excludedSpeciesSubexpression = excludedSpeciesWithMixedParents.length == 0
+    ? undefined
+    : `${excludedSpeciesWithMixedParents.join('+')}=0T`;
+
+  const subexpressions = [
+    nonSpeciesSubexpression,
+    includedSpeciesSubexpression,
+    excludedSpeciesSubexpression
+  ];
+
+  return (
+    subexpressions
+      .filter(subexpression => subexpression != null)
+      .join(' AND ')
+  );
+
+  function _traverse(node: PhyleticExpressionUiTree) {
+    const nextConstraintType = constraintStates[node.abbrev];
+
+    if (nextConstraintType === 'include-all') {
+      nonSpeciesExpressionTerms.push(`${node.abbrev}=${node.speciesCount}T`);
+    } else if (nextConstraintType === 'include-at-least-one') {
+      nonSpeciesExpressionTerms.push(`${node.abbrev}>=1T`);
+    } else if (nextConstraintType === 'exclude') {
+      nonSpeciesExpressionTerms.push(`${node.abbrev}=0T`);
+    } else if (nextConstraintType === 'mixed') {
+      const [ speciesChildren, nonSpeciesChildren ] = partition(
+        node.children,
+        child => child.species
+      );
+
+      const speciesChildrenAbbrevs = mapValues(
+        speciesChildren,
+        speciesChild => speciesChild.abbrev
+      );
+
+      const speciesChildrenAbbrevsByState = groupBy(
+        speciesChildrenAbbrevs,
+        speciesChildAbbrev => constraintStates[speciesChildAbbrev]
+      );
+
+      const includedSpeciesAbbrevs = speciesChildrenAbbrevsByState['include-all'] ?? [];
+      const excludedSpeciesAbbrevs = speciesChildrenAbbrevsByState['exclude'] ?? [];
+
+      includedSpeciesWithMixedParents.push(...includedSpeciesAbbrevs);
+      excludedSpeciesWithMixedParents.push(...excludedSpeciesAbbrevs);
+
+      nonSpeciesChildren.forEach(_traverse);
+    }
+  }
+}

--- a/Site/webapp/wdkCustomization/js/client/utils/phyleticPattern.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/phyleticPattern.ts
@@ -115,7 +115,7 @@ const SPECIES_STATE_ORDER = [ 'free', 'include-all', 'exclude' ] as HomogeneousC
 export function updateParentConstraintStates(
   node: PhyleticExpressionUiTree,
   draftConstraintStates: ConstraintStates,
-  changedState: HomogeneousConstraintState
+  changedState: ConstraintState
 ): void {
   const parent = node.parent;
 
@@ -126,16 +126,16 @@ export function updateParentConstraintStates(
       )
     );
 
-    if (
+    const newParentState = (
       distinctChildConstraintTypes.size === 1 &&
-      changedState !== 'include-at-least-one'
-    ) {
-      draftConstraintStates[parent.abbrev] = changedState;
-    } else {
-      draftConstraintStates[parent.abbrev] = 'mixed';
-    }
+      changedState !== 'include-at-least-one'     
+    )
+      ? changedState
+      : 'mixed';
 
-    updateParentConstraintStates(parent, draftConstraintStates, changedState);
+    draftConstraintStates[parent.abbrev] = newParentState;
+
+    updateParentConstraintStates(parent, draftConstraintStates, newParentState);
   }
 }
 

--- a/Site/webapp/wdkCustomization/js/client/utils/taxons.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/taxons.ts
@@ -76,7 +76,6 @@ export const makeTaxonTree = function(taxonEntries: TaxonEntries): TaxonTree {
 };
 
 export interface TaxonUiMetadata {
-  parents: Record<string, TaxonTree | null>;
   rootTaxons: Record<string, RootTaxonEntry>;
   species: Record<string, SpeciesEntry>;
   taxonOrder: string[];
@@ -95,21 +94,18 @@ export interface SpeciesEntry extends TaxonEntry {
 }
 
 export function makeTaxonUiMetadata(taxonEntries: TaxonEntries, taxonTree: TaxonTree): TaxonUiMetadata {
-  const parents = {} as TaxonUiMetadata['parents'];
   const rootTaxons = {} as TaxonUiMetadata['rootTaxons'];
   const species = {} as TaxonUiMetadata['species'];
   const taxonOrder = [] as TaxonUiMetadata['taxonOrder'];
 
   _traverseTaxonTree({
     node: taxonTree,
-    parent: undefined,
     groupColor: undefined,
     rootTaxon: undefined,
     path: []
   });
 
   return {
-    parents,
     rootTaxons,
     species,
     taxonOrder,
@@ -118,13 +114,11 @@ export function makeTaxonUiMetadata(taxonEntries: TaxonEntries, taxonTree: Taxon
 
   function _traverseTaxonTree({
     node,
-    parent,
     groupColor,
     rootTaxon,
     path
   }: {
     node: TaxonTree,
-    parent: TaxonTree | undefined,
     groupColor: string | undefined,
     rootTaxon: string | undefined,
     path: string[]
@@ -136,8 +130,6 @@ export function makeTaxonUiMetadata(taxonEntries: TaxonEntries, taxonTree: Taxon
     if (taxonEntry == null) {
       throw new Error(`The taxon entry for "${taxonAbbrev}" is missing.`);
     }
-
-    parents[taxonAbbrev] = parent ?? null;
 
     // A taxon is a root taxon iff its taxon entry has a group color
     if (taxonEntry.groupColor != null) {
@@ -174,7 +166,6 @@ export function makeTaxonUiMetadata(taxonEntries: TaxonEntries, taxonTree: Taxon
     node.children.forEach(childNode => {
       _traverseTaxonTree({
         node: childNode,
-        parent: node,
         groupColor: groupColor ?? taxonEntry.groupColor,
         rootTaxon: rootTaxon ?? (taxonEntry.groupColor && taxonEntry.abbrev),
         path: newPath

--- a/Site/webapp/wdkCustomization/js/client/utils/taxons.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/taxons.ts
@@ -39,10 +39,9 @@ export const taxonEntryDecoder: Decoder<TaxonEntry> = record({
 
 export const taxonEntriesDecoder: Decoder<TaxonEntries> = objectOf(taxonEntryDecoder);
 
-export interface TaxonTree {
-  abbrev: string;
+export interface TaxonTree extends Omit<TaxonEntry, 'children'> {
   children: TaxonTree[];
-};
+}
 
 export const ROOT_TAXON_ABBREV = 'ALL';
 
@@ -70,7 +69,7 @@ export const makeTaxonTree = function(taxonEntries: TaxonEntries): TaxonTree {
     );
 
     return {
-      abbrev: entry.abbrev,
+      ...entry,
       children: orderedChildren
     };
   }
@@ -81,6 +80,7 @@ export interface TaxonUiMetadata {
   rootTaxons: Record<string, RootTaxonEntry>;
   species: Record<string, SpeciesEntry>;
   taxonOrder: string[];
+  taxonTree: TaxonTree;
 }
 
 export interface RootTaxonEntry extends TaxonEntry {
@@ -112,7 +112,8 @@ export function makeTaxonUiMetadata(taxonEntries: TaxonEntries, taxonTree: Taxon
     parents,
     rootTaxons,
     species,
-    taxonOrder
+    taxonOrder,
+    taxonTree
   };
 
   function _traverseTaxonTree({

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { Props } from 'wdk-client/Views/Question/DefaultQuestionForm';
+
+export function GroupsByPhyleticPattern(props: Props) {
+  return (
+    <div>Future Home Of Groups By Phyletic Pattern Custom Search Page</div>
+  );
+}

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-
-import { Props } from 'wdk-client/Views/Question/DefaultQuestionForm';
-
-export function GroupsByPhyleticPattern(props: Props) {
-  return (
-    <div>Future Home Of Groups By Phyletic Pattern Custom Search Page</div>
-  );
-}

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
@@ -1,0 +1,5 @@
+.wdk-QuestionForm {
+  &GroupsByPhyleticPattern {
+    max-width: 110em;
+  }
+}

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
@@ -2,6 +2,13 @@
   &GroupsByPhyleticPattern {
     max-width: 110em;
 
+    .PhyleticExpression--Instructions {
+      .wdk-Icon {
+        font-size: 1.2em;
+        color: #AAA;
+      }
+    }
+
     .PhyleticExpression--ConstraintIcon {
       &__free {
         content: url('~ortho-images/dc.gif');

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
@@ -27,6 +27,7 @@
 
         &__mixed {
           content: url('~ortho-images/unk.gif');
+          margin-right: 2px;
         }
       }
     }

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
@@ -6,17 +6,17 @@
       display: flex;
       align-items: center;
 
-      &Selection {
+      &Constraint {
         &__free {
           content: url('~ortho-images/dc.gif');
         }
 
-        &__include-all {
-          content: url('~ortho-images/yes.gif');
-        }
-
         &__include-at-least-one {
           content: url('~ortho-images/maybe.gif');
+        }
+
+        &__include-all {
+          content: url('~ortho-images/yes.gif');
         }
 
         &__exclude {

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
@@ -28,5 +28,24 @@
         }
       }
     }
+
+    .PhyleticExpression--TextField {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      input {
+        width: 80em;
+        margin: 0 2em 0 1em;
+      }
+
+      .PhyleticExpression--SubmitButtonContainer {
+        width: 160px;
+
+        button.btn {
+          margin-left: 0;
+        }
+      }
+    }
   }
 }

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
@@ -2,6 +2,29 @@
   &GroupsByPhyleticPattern {
     max-width: 110em;
 
+    .PhyleticExpression--ConstraintIcon {
+      &__free {
+        content: url('~ortho-images/dc.gif');
+      }
+
+      &__include-at-least-one {
+        content: url('~ortho-images/maybe.gif');
+      }
+
+      &__include-all {
+        content: url('~ortho-images/yes.gif');
+      }
+
+      &__exclude {
+        content: url('~ortho-images/no.gif');
+      }
+
+      &__mixed {
+        content: url('~ortho-images/unk.gif');
+        margin-right: 2px;
+      }
+    }
+
     .PhyleticExpression--Node {
       display: flex;
       align-items: center;
@@ -14,27 +37,6 @@
 
       &Constraint {
         cursor: pointer;
-
-        &__free {
-          content: url('~ortho-images/dc.gif');
-        }
-
-        &__include-at-least-one {
-          content: url('~ortho-images/maybe.gif');
-        }
-
-        &__include-all {
-          content: url('~ortho-images/yes.gif');
-        }
-
-        &__exclude {
-          content: url('~ortho-images/no.gif');
-        }
-
-        &__mixed {
-          content: url('~ortho-images/unk.gif');
-          margin-right: 2px;
-        }
       }
 
       &Description {
@@ -59,6 +61,22 @@
           margin-left: 0;
         }
       }
+    }
+
+    .wdk-CheckboxTree {
+      position: relative;
+      font-size: 1.1em;
+
+      &Links {
+        position: absolute;
+        left: 8em;
+        top: 0.5em;
+        z-index: 1;
+      }
+    }
+
+    .wdk-CheckboxTree > .wdk-CheckboxTreeList > .wdk-CheckboxTreeItem > .wdk-CheckboxTreeNodeWrapper > i {
+      display: none;
     }
 
     .wdk-CheckboxTreeItem .wdk-CheckboxTreeNodeWrapper:hover {

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
@@ -6,6 +6,12 @@
       display: flex;
       align-items: center;
 
+      font-weight: bold;
+
+      &__species {
+        font-weight: normal;
+      }
+
       &Constraint {
         cursor: pointer;
 
@@ -29,6 +35,10 @@
           content: url('~ortho-images/unk.gif');
           margin-right: 2px;
         }
+      }
+
+      &Description {
+        margin-left: 0.25em;
       }
     }
 

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
@@ -1,5 +1,32 @@
 .wdk-QuestionForm {
   &GroupsByPhyleticPattern {
     max-width: 110em;
+
+    .PhyleticExpression--Node {
+      display: flex;
+      align-items: center;
+
+      &Selection {
+        &__free {
+          content: url('~ortho-images/dc.gif');
+        }
+
+        &__include-all {
+          content: url('~ortho-images/yes.gif');
+        }
+
+        &__include-at-least-one {
+          content: url('~ortho-images/maybe.gif');
+        }
+
+        &__exclude {
+          content: url('~ortho-images/no.gif');
+        }
+
+        &__mixed {
+          content: url('~ortho-images/unk.gif');
+        }
+      }
+    }
   }
 }

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
@@ -7,6 +7,8 @@
       align-items: center;
 
       &Constraint {
+        cursor: pointer;
+
         &__free {
           content: url('~ortho-images/dc.gif');
         }
@@ -46,6 +48,11 @@
           margin-left: 0;
         }
       }
+    }
+
+    .wdk-CheckboxTreeItem .wdk-CheckboxTreeNodeWrapper:hover {
+      cursor: default;
+      text-decoration: none;
     }
   }
 }

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.scss
@@ -9,6 +9,31 @@
       }
     }
 
+    .PhyleticExpression--IconLegend {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.1em;
+      border: 0.0625rem solid black;
+      padding: 0.5em;
+      margin: 1em 0;
+
+      .PhyleticExpression--ConstraintIcon {
+        margin-left: 0.25em;
+      }
+
+      &Header {
+        margin-right: 0.5em;
+
+        font-weight: bold;
+      }
+
+      &Content {
+        display: flex;
+        align-items: center;
+      }
+    }
+
     .PhyleticExpression--ConstraintIcon {
       &__free {
         content: url('~ortho-images/dc.gif');

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -32,6 +32,15 @@ export function Form(props: Props) {
     [ taxonUiMetadata ]
   );
 
+  const updatePhyleticPatternParam = useCallback((newParamValue: string) => {
+    props.eventHandlers.updateParamValue({
+      searchName: props.state.question.urlSegment,
+      parameter: props.state.question.parametersByName[PHYLETIC_EXPRESSION_PARAM_NAME],
+      paramValues: props.state.paramValues,
+      paramValue: newParamValue
+    });
+  }, [ props.eventHandlers, props.state.question, props.state.paramValues ]);
+
   const renderParamGroup = useCallback((group: ParameterGroup, formProps: Props) => {
     return (
       <div key={group.name} className={cxDefaultQuestionForm('ParameterList')}>
@@ -42,12 +51,13 @@ export function Form(props: Props) {
             : <PhyleticExpressionParameter
                 phyleticExpressionTextField={formProps.parameterElements[PHYLETIC_EXPRESSION_PARAM_NAME]}
                 phyleticExpressionUiTree={phyleticExpressionUiTree}
+                updatePhyleticPatternParam={updatePhyleticPatternParam}
               />
         }
         </div>
       </div>
     );
-  }, [ phyleticExpressionUiTree ]);
+  }, [ phyleticExpressionUiTree, updatePhyleticPatternParam ]);
 
   return (
     <EbrcDefaultQuestionForm
@@ -61,6 +71,7 @@ export function Form(props: Props) {
 interface PhyleticExpressionParameterProps {
   phyleticExpressionTextField: React.ReactNode;
   phyleticExpressionUiTree: PhyleticExpressionUiTree;
+  updatePhyleticPatternParam: (newParamValue: string) => void;
 }
 
 interface PhyleticExpressionUiTree extends TaxonTree {
@@ -81,7 +92,8 @@ type ConstraintState = HomogeneousConstraintState | 'mixed';
 
 function PhyleticExpressionParameter({
   phyleticExpressionTextField,
-  phyleticExpressionUiTree
+  phyleticExpressionUiTree,
+  updatePhyleticPatternParam
 }: PhyleticExpressionParameterProps) {
   const [ expandedNodes, setExpandedNodes ] = useState([] as string[]);
 
@@ -94,8 +106,12 @@ function PhyleticExpressionParameter({
   }, [ phyleticExpressionUiTree ]);
 
   const renderNode = useMemo(
-    () => makeRenderNode(constraintStates, setConstraintStates),
-    [ constraintStates ]
+    () => makeRenderNode(
+      constraintStates,
+      setConstraintStates,
+      updatePhyleticPatternParam
+    ),
+    [ constraintStates, updatePhyleticPatternParam ]
   );
 
   console.log(phyleticExpressionUiTree);
@@ -175,7 +191,8 @@ function getNodeChildren(node: PhyleticExpressionUiTree) {
 
 function makeRenderNode(
   constraintStates: ConstraintStates,
-  setConstraintStates: (newConstraintStates: ConstraintStates) => void
+  setConstraintStates: (newConstraintStates: ConstraintStates) => void,
+  updatePhyleticPatternParam: (newParamValue: string) => void
 ) {
   return function(node: PhyleticExpressionUiTree, path: number[] | undefined) {
     const containerClassName = cxPhyleticExpression(

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -1,17 +1,23 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
-import { Loading } from 'wdk-client/Components';
+import { orderBy } from 'lodash';
+
+import { CheckboxTree, Loading } from 'wdk-client/Components';
+import { LinksPosition } from 'wdk-client/Components/CheckboxTree/CheckboxTree';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
+import { mapStructure } from 'wdk-client/Utils/TreeUtils';
 import { ParameterGroup } from 'wdk-client/Utils/WdkModel';
 import { Props } from 'wdk-client/Views/Question/DefaultQuestionForm';
 
 import { EbrcDefaultQuestionForm } from 'ebrc-client/components/questions/EbrcDefaultQuestionForm';
 
 import { useTaxonUiMetadata } from 'ortho-client/hooks/taxons';
+import { TaxonTree } from 'ortho-client/utils/taxons';
 
 import './Form.scss';
 
 const cxDefaultQuestionForm = makeClassNameHelper('wdk-QuestionForm');
+const cxPhyleticExpression = makeClassNameHelper('PhyleticExpression');
 
 const PHYLETIC_EXPRESSION_PARAM_NAME = 'phyletic_expression';
 
@@ -44,13 +50,92 @@ interface PhyleticExpressionParameterProps {
 function PhyleticExpressionParameter(props: PhyleticExpressionParameterProps) {
   const taxonUiMetadata = useTaxonUiMetadata();
 
+  const [ expandedNodes, setExpandedNodes ] = useState([] as string[]);
+
+  const phyleticExressionUiTree = useMemo(
+    () => taxonUiMetadata == null
+      ? undefined
+      : makePhyleticExpressionUiTree(taxonUiMetadata.taxonTree),
+    [ taxonUiMetadata ]
+  );
+
+  return phyleticExressionUiTree == null
+    ? <Loading />
+    : <div className="PhyleticExpressionParameter">
+        {props.phyleticExpressionTextField}
+        <CheckboxTree
+          tree={phyleticExressionUiTree}
+          getNodeId={getNodeId}
+          getNodeChildren={getNodeChildren}
+          onExpansionChange={setExpandedNodes}
+          shouldExpandOnClick={false}
+          expandedList={expandedNodes}
+          renderNode={renderNode}
+          showRoot
+          linksPosition={LinksPosition.Top}
+        />
+      </div>;
+}
+
+type SelectionState =
+  | 'free'
+  | 'include-at-least-one'
+  | 'include-all'
+  | 'exclude'
+  | 'mixed';
+
+interface PhyleticExressionUiTree extends TaxonTree {
+  children: PhyleticExressionUiTree[];
+  selectionState: SelectionState;
+  speciesCount: number;
+}
+
+function makePhyleticExpressionUiTree(taxonTree: TaxonTree): PhyleticExressionUiTree {
+  return mapStructure(
+    (node, mappedChildren) => ({
+      ...node,
+      children: orderBy(
+        mappedChildren,
+        child => child.species,
+        'desc'
+      ),
+      selectionState: 'free',
+      speciesCount: node.species
+        ? 1
+        : mappedChildren.reduce(
+            (memo, { speciesCount }) => memo + speciesCount,
+            0
+          )
+    }),
+    taxonTree => taxonTree.children,
+    taxonTree
+  );
+}
+
+function getNodeId(node: PhyleticExressionUiTree) {
+  return node.abbrev;
+}
+
+function getNodeChildren(node: PhyleticExressionUiTree) {
+  return node.children;
+}
+
+function renderNode(node: PhyleticExressionUiTree, path: number[] | undefined) {
+  const containerClassName = cxPhyleticExpression(
+    '--Node',
+    path?.length === 1 ? 'root' : 'interior',
+    node.species && 'species'
+  );
+
+  const selectionClassName = cxPhyleticExpression(
+    '--NodeSelection',
+    node.selectionState
+  );
+
   return (
-    <div className="PhyleticExpressionParameter">
-      {
-        taxonUiMetadata == null
-          ? <Loading />
-          : props.phyleticExpressionTextField
-      }
+    <div className={containerClassName}>
+      <span className={selectionClassName}></span>
+      <span>{node.name} ({node.abbrev})</span>
     </div>
   );
 }

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -77,7 +77,7 @@ function PhyleticExpressionParameter(props: PhyleticExpressionParameterProps) {
       </div>;
 }
 
-type SelectionState =
+type ConstraintState =
   | 'free'
   | 'include-at-least-one'
   | 'include-all'
@@ -86,7 +86,7 @@ type SelectionState =
 
 interface PhyleticExressionUiTree extends TaxonTree {
   children: PhyleticExressionUiTree[];
-  selectionState: SelectionState;
+  constraintState: ConstraintState;
   speciesCount: number;
 }
 
@@ -99,7 +99,7 @@ function makePhyleticExpressionUiTree(taxonTree: TaxonTree): PhyleticExressionUi
         child => child.species,
         'desc'
       ),
-      selectionState: 'free',
+      constraintState: 'free',
       speciesCount: node.species
         ? 1
         : mappedChildren.reduce(
@@ -127,14 +127,14 @@ function renderNode(node: PhyleticExressionUiTree, path: number[] | undefined) {
     node.species && 'species'
   );
 
-  const selectionClassName = cxPhyleticExpression(
-    '--NodeSelection',
-    node.selectionState
+  const constraintClassName = cxPhyleticExpression(
+    '--NodeConstraint',
+    node.constraintState
   );
 
   return (
     <div className={containerClassName}>
-      <span className={selectionClassName}></span>
+      <span className={constraintClassName}></span>
       <span>{node.name} ({node.abbrev})</span>
     </div>
   );

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -115,9 +115,6 @@ function PhyleticExpressionParameter({
     [ constraintStates, phyleticExpressionUiTree, updatePhyleticExpressionParam ]
   );
 
-  console.log(phyleticExpressionUiTree);
-  console.log(constraintStates);
-
   return (
     <div className="PhyleticExpressionParameter">
       {phyleticExpressionTextField}

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -70,12 +70,13 @@ interface PhyleticExpressionUiTree extends TaxonTree {
 
 type ConstraintStates = Record<string, ConstraintState>;
 
-type ConstraintState =
+type HomogeneousConstraintState =
   | 'free'
   | 'include-at-least-one'
   | 'include-all'
-  | 'exclude'
-  | 'mixed';
+  | 'exclude';
+
+type ConstraintState = HomogeneousConstraintState | 'mixed';
 
 function PhyleticExpressionParameter({
   phyleticExpressionTextField,
@@ -192,3 +193,20 @@ function makeRenderNode(constraintStates: ConstraintStates) {
     );
   }
 }
+
+function getNextState(currentState: ConstraintState, isSpecies: boolean): HomogeneousConstraintState {
+  if (currentState === 'mixed') {
+    return 'include-all';
+  }
+
+  const stateOrder = isSpecies
+    ? SPECIES_STATE_ORDER
+    : NON_SPECIES_STATE_ORDER;
+
+  const stateIndex = stateOrder.indexOf(currentState);
+
+  return stateOrder[(stateIndex + 1) % stateOrder.length];
+}
+
+const NON_SPECIES_STATE_ORDER = [ 'free', 'include-all', 'include-at-least-one', 'exclude' ] as const;
+const SPECIES_STATE_ORDER = [ 'free', 'include-all', 'exclude' ] as HomogeneousConstraintState[];

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -17,7 +17,9 @@ export function Form(props: Props) {
     return (
       <div key={group.name} className={cxDefaultQuestionForm('ParameterList')}>
         <div className={cxDefaultQuestionForm('ParameterControl')}>
-          {formProps.parameterElements[PHYLETIC_EXPRESSION_PARAM_NAME]}
+          <PhyleticExpressionParameter
+            phyleticExpressionTextField={formProps.parameterElements[PHYLETIC_EXPRESSION_PARAM_NAME]}
+          />
         </div>
       </div>
     );
@@ -29,5 +31,17 @@ export function Form(props: Props) {
       containerClassName={`${cxDefaultQuestionForm()} ${cxDefaultQuestionForm('GroupsByPhyleticPattern')}`}
       renderParamGroup={renderParamGroup}
     />
+  );
+}
+
+interface PhyleticExpressionParameterProps {
+  phyleticExpressionTextField: React.ReactNode;
+}
+
+function PhyleticExpressionParameter(props: PhyleticExpressionParameterProps) {
+  return (
+    <div className="PhyleticExpressionParameter">
+      {props.phyleticExpressionTextField}
+    </div>
   );
 }

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -1,0 +1,33 @@
+import React, { useCallback } from 'react';
+
+import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
+import { ParameterGroup } from 'wdk-client/Utils/WdkModel';
+import { Props } from 'wdk-client/Views/Question/DefaultQuestionForm';
+
+import { EbrcDefaultQuestionForm } from 'ebrc-client/components/questions/EbrcDefaultQuestionForm';
+
+import './Form.scss';
+
+const cxDefaultQuestionForm = makeClassNameHelper('wdk-QuestionForm');
+
+const PHYLETIC_EXPRESSION_PARAM_NAME = 'phyletic_expression';
+
+export function Form(props: Props) {
+  const renderParamGroup = useCallback((group: ParameterGroup, formProps: Props) => {
+    return (
+      <div key={group.name} className={cxDefaultQuestionForm('ParameterList')}>
+        <div className={cxDefaultQuestionForm('ParameterControl')}>
+          {formProps.parameterElements[PHYLETIC_EXPRESSION_PARAM_NAME]}
+        </div>
+      </div>
+    );
+  }, []);
+
+  return (
+    <EbrcDefaultQuestionForm
+      {...props}
+      containerClassName={`${cxDefaultQuestionForm()} ${cxDefaultQuestionForm('GroupsByPhyleticPattern')}`}
+      renderParamGroup={renderParamGroup}
+    />
+  );
+}

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -170,6 +170,18 @@ function PhyleticExpressionParameter({
           />
         </div>
       </div>
+      <div className={cxPhyleticExpression('--IconLegend')}>
+        <div className={cxPhyleticExpression('--IconLegendHeader')}>
+          Key:
+        </div>
+        <div className={cxPhyleticExpression('--IconLegendContents')}>
+          <ConstraintIcon constraintType="free" /> = no constraints |
+          <ConstraintIcon constraintType="include-all" /> = must be in group |
+          <ConstraintIcon constraintType="include-at-least-one" /> = at least one subtaxon must be in group |
+          <ConstraintIcon constraintType="exclude" /> = must not be in group |
+          <ConstraintIcon constraintType="mixed" /> = mixture of constraints
+        </div>
+      </div>
       <CheckboxTree
         tree={phyleticExpressionUiTree}
         getNodeId={getNodeId}

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -8,7 +8,7 @@ import { LinksPosition } from 'wdk-client/Components/CheckboxTree/CheckboxTree';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
 import { foldStructure, mapStructure } from 'wdk-client/Utils/TreeUtils';
 import { ParameterGroup } from 'wdk-client/Utils/WdkModel';
-import { Props } from 'wdk-client/Views/Question/DefaultQuestionForm';
+import { Props, SubmitButton } from 'wdk-client/Views/Question/DefaultQuestionForm';
 
 import { EbrcDefaultQuestionForm } from 'ebrc-client/components/questions/EbrcDefaultQuestionForm';
 
@@ -45,15 +45,18 @@ export function Form(props: Props) {
     return (
       <div key={group.name} className={cxDefaultQuestionForm('ParameterList')}>
         <div className={cxDefaultQuestionForm('ParameterControl')}>
-        {
-          phyleticExpressionUiTree == null
-            ? <Loading />
-            : <PhyleticExpressionParameter
-                phyleticExpressionTextField={formProps.parameterElements[PHYLETIC_EXPRESSION_PARAM_NAME]}
-                phyleticExpressionUiTree={phyleticExpressionUiTree}
-                updatePhyleticExpressionParam={updatePhyleticExpressionParam}
-              />
-        }
+          {
+            phyleticExpressionUiTree == null
+              ? <Loading />
+              : <PhyleticExpressionParameter
+                  phyleticExpressionTextField={formProps.parameterElements[PHYLETIC_EXPRESSION_PARAM_NAME]}
+                  phyleticExpressionUiTree={phyleticExpressionUiTree}
+                  submissionMetadata={formProps.submissionMetadata}
+                  submitButtonText={formProps.submitButtonText}
+                  submitting={formProps.state.submitting}
+                  updatePhyleticExpressionParam={updatePhyleticExpressionParam}
+                />
+          }
         </div>
       </div>
     );
@@ -71,6 +74,9 @@ export function Form(props: Props) {
 interface PhyleticExpressionParameterProps {
   phyleticExpressionTextField: React.ReactNode;
   phyleticExpressionUiTree: PhyleticExpressionUiTree;
+  submissionMetadata: Props['submissionMetadata'];
+  submitButtonText: Props['submitButtonText'];
+  submitting: Props['state']['submitting'];
   updatePhyleticExpressionParam: (newParamValue: string) => void;
 }
 
@@ -93,6 +99,9 @@ type ConstraintState = HomogeneousConstraintState | 'mixed';
 function PhyleticExpressionParameter({
   phyleticExpressionTextField,
   phyleticExpressionUiTree,
+  submissionMetadata,
+  submitButtonText,
+  submitting,
   updatePhyleticExpressionParam
 }: PhyleticExpressionParameterProps) {
   const [ expandedNodes, setExpandedNodes ] = useState([] as string[]);
@@ -116,8 +125,18 @@ function PhyleticExpressionParameter({
   );
 
   return (
-    <div className="PhyleticExpressionParameter">
-      {phyleticExpressionTextField}
+    <div className={cxPhyleticExpression('--Parameter')}>
+      <div className={cxPhyleticExpression('--TextField')}>
+        Expression:
+        {phyleticExpressionTextField}
+        <div className={cxPhyleticExpression('--SubmitButtonContainer')}>
+          <SubmitButton
+            submissionMetadata={submissionMetadata}
+            submitButtonText={submitButtonText}
+            submitting={submitting}
+          />
+        </div>
+      </div>
       <CheckboxTree
         tree={phyleticExpressionUiTree}
         getNodeId={getNodeId}

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -5,7 +5,7 @@ import { orderBy } from 'lodash';
 import { CheckboxTree, Loading } from 'wdk-client/Components';
 import { LinksPosition } from 'wdk-client/Components/CheckboxTree/CheckboxTree';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
-import { mapStructure } from 'wdk-client/Utils/TreeUtils';
+import { foldStructure, mapStructure } from 'wdk-client/Utils/TreeUtils';
 import { ParameterGroup } from 'wdk-client/Utils/WdkModel';
 import { Props } from 'wdk-client/Views/Question/DefaultQuestionForm';
 
@@ -22,17 +22,31 @@ const cxPhyleticExpression = makeClassNameHelper('PhyleticExpression');
 const PHYLETIC_EXPRESSION_PARAM_NAME = 'phyletic_expression';
 
 export function Form(props: Props) {
+  const taxonUiMetadata = useTaxonUiMetadata();
+
+  const phyleticExpressionUiTree = useMemo(
+    () => taxonUiMetadata == null
+      ? undefined
+      : makePhyleticExpressionUiTree(taxonUiMetadata.taxonTree),
+    [ taxonUiMetadata ]
+  );
+
   const renderParamGroup = useCallback((group: ParameterGroup, formProps: Props) => {
     return (
       <div key={group.name} className={cxDefaultQuestionForm('ParameterList')}>
         <div className={cxDefaultQuestionForm('ParameterControl')}>
-          <PhyleticExpressionParameter
-            phyleticExpressionTextField={formProps.parameterElements[PHYLETIC_EXPRESSION_PARAM_NAME]}
-          />
+        {
+          phyleticExpressionUiTree == null
+            ? <Loading />
+            : <PhyleticExpressionParameter
+                phyleticExpressionTextField={formProps.parameterElements[PHYLETIC_EXPRESSION_PARAM_NAME]}
+                phyleticExpressionUiTree={phyleticExpressionUiTree}
+              />
+        }
         </div>
       </div>
     );
-  }, []);
+  }, [ phyleticExpressionUiTree ]);
 
   return (
     <EbrcDefaultQuestionForm
@@ -45,43 +59,16 @@ export function Form(props: Props) {
 
 interface PhyleticExpressionParameterProps {
   phyleticExpressionTextField: React.ReactNode;
+  phyleticExpressionUiTree: PhyleticExpressionUiTree;
 }
 
-function PhyleticExpressionParameter(props: PhyleticExpressionParameterProps) {
-  const taxonUiMetadata = useTaxonUiMetadata();
-
-  const [ expandedNodes, setExpandedNodes ] = useState([] as string[]);
-
-  const initialPhyleticExpressionUiTree = useMemo(
-    () => taxonUiMetadata == null
-      ? undefined
-      : makePhyleticExpressionUiTree(taxonUiMetadata.taxonTree),
-    [ taxonUiMetadata ]
-  );
-
-  const [ phyleticExpressionUiTree, setPhyleticExpressionUiTree ] = useState(initialPhyleticExpressionUiTree);
-
-  useEffect(() => {
-    setPhyleticExpressionUiTree(initialPhyleticExpressionUiTree);
-  }, [ initialPhyleticExpressionUiTree ]);
-
-  return phyleticExpressionUiTree == null
-    ? <Loading />
-    : <div className="PhyleticExpressionParameter">
-        {props.phyleticExpressionTextField}
-        <CheckboxTree
-          tree={phyleticExpressionUiTree}
-          getNodeId={getNodeId}
-          getNodeChildren={getNodeChildren}
-          onExpansionChange={setExpandedNodes}
-          shouldExpandOnClick={false}
-          expandedList={expandedNodes}
-          renderNode={renderNode}
-          showRoot
-          linksPosition={LinksPosition.Top}
-        />
-      </div>;
+interface PhyleticExpressionUiTree extends TaxonTree {
+  children: PhyleticExpressionUiTree[];
+  parent?: PhyleticExpressionUiTree;
+  speciesCount: number;
 }
+
+type ConstraintStates = Record<string, ConstraintState>;
 
 type ConstraintState =
   | 'free'
@@ -90,22 +77,55 @@ type ConstraintState =
   | 'exclude'
   | 'mixed';
 
-interface PhyleticExpressionUiTree extends TaxonTree {
-  children: PhyleticExpressionUiTree[];
-  constraintState: ConstraintState;
-  speciesCount: number;
+function PhyleticExpressionParameter({
+  phyleticExpressionTextField,
+  phyleticExpressionUiTree
+}: PhyleticExpressionParameterProps) {
+  const [ expandedNodes, setExpandedNodes ] = useState([] as string[]);
+
+  const [ constraintStates, setConstraintStates ] = useState(
+    () => makeInitialConstraintStates(phyleticExpressionUiTree)
+  );
+
+  useEffect(() => {
+    setConstraintStates(makeInitialConstraintStates(phyleticExpressionUiTree));
+  }, [ phyleticExpressionUiTree ]);
+
+  const renderNode = useMemo(
+    () => makeRenderNode(constraintStates),
+    [ constraintStates ]
+  );
+
+  console.log(phyleticExpressionUiTree);
+  console.log(constraintStates);
+
+  return (
+    <div className="PhyleticExpressionParameter">
+      {phyleticExpressionTextField}
+      <CheckboxTree
+        tree={phyleticExpressionUiTree}
+        getNodeId={getNodeId}
+        getNodeChildren={getNodeChildren}
+        onExpansionChange={setExpandedNodes}
+        shouldExpandOnClick={false}
+        expandedList={expandedNodes}
+        renderNode={renderNode}
+        showRoot
+        linksPosition={LinksPosition.Top}
+      />
+    </div>
+  );
 }
 
-function makePhyleticExpressionUiTree(taxonTree: TaxonTree): PhyleticExpressionUiTree {
-  return mapStructure(
-    (node, mappedChildren) => ({
+function makePhyleticExpressionUiTree(taxonTree: TaxonTree) {
+  const phyleticExpressionUiTree = mapStructure(
+    (node: TaxonTree, mappedChildren: PhyleticExpressionUiTree[]) => ({
       ...node,
       children: orderBy(
         mappedChildren,
         child => child.species,
         'desc'
       ),
-      constraintState: 'free',
       speciesCount: node.species
         ? 1
         : mappedChildren.reduce(
@@ -113,8 +133,33 @@ function makePhyleticExpressionUiTree(taxonTree: TaxonTree): PhyleticExpressionU
             0
           )
     }),
-    taxonTree => taxonTree.children,
+    (node: TaxonTree) => node.children,
     taxonTree
+  );
+
+  _addParentRefs(phyleticExpressionUiTree, undefined);
+
+  return phyleticExpressionUiTree;
+
+  function _addParentRefs(node: PhyleticExpressionUiTree, parent: PhyleticExpressionUiTree | undefined) {
+    if (parent != null) {
+      node.parent = parent;
+    }
+
+    node.children.forEach(child => {
+      _addParentRefs(child, node);
+    });
+  }
+}
+
+function makeInitialConstraintStates(phyleticExpressionUiTree: PhyleticExpressionUiTree) {
+  return foldStructure(
+    (constraintStates: ConstraintStates, node: PhyleticExpressionUiTree) => {
+      constraintStates[node.abbrev] = 'free';
+      return constraintStates;
+    },
+    {} as ConstraintStates,
+    phyleticExpressionUiTree
   );
 }
 
@@ -126,22 +171,24 @@ function getNodeChildren(node: PhyleticExpressionUiTree) {
   return node.children;
 }
 
-function renderNode(node: PhyleticExpressionUiTree, path: number[] | undefined) {
-  const containerClassName = cxPhyleticExpression(
-    '--Node',
-    path?.length === 1 ? 'root' : 'interior',
-    node.species && 'species'
-  );
+function makeRenderNode(constraintStates: ConstraintStates) {
+  return function(node: PhyleticExpressionUiTree, path: number[] | undefined) {
+    const containerClassName = cxPhyleticExpression(
+      '--Node',
+      path?.length === 1 ? 'root' : 'interior',
+      node.species && 'species'
+    );
 
-  const constraintClassName = cxPhyleticExpression(
-    '--NodeConstraint',
-    node.constraintState
-  );
+    const constraintClassName = cxPhyleticExpression(
+      '--NodeConstraint',
+      constraintStates[node.abbrev]
+    );
 
-  return (
-    <div className={containerClassName}>
-      <span className={constraintClassName}></span>
-      <span>{node.name} ({node.abbrev})</span>
-    </div>
-  );
+    return (
+      <div className={containerClassName}>
+        <span className={constraintClassName}></span>
+        <span>{node.name} ({node.abbrev})</span>
+      </div>
+    );
+  }
 }

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { orderBy } from 'lodash';
 
@@ -52,19 +52,25 @@ function PhyleticExpressionParameter(props: PhyleticExpressionParameterProps) {
 
   const [ expandedNodes, setExpandedNodes ] = useState([] as string[]);
 
-  const phyleticExressionUiTree = useMemo(
+  const initialPhyleticExpressionUiTree = useMemo(
     () => taxonUiMetadata == null
       ? undefined
       : makePhyleticExpressionUiTree(taxonUiMetadata.taxonTree),
     [ taxonUiMetadata ]
   );
 
-  return phyleticExressionUiTree == null
+  const [ phyleticExpressionUiTree, setPhyleticExpressionUiTree ] = useState(initialPhyleticExpressionUiTree);
+
+  useEffect(() => {
+    setPhyleticExpressionUiTree(initialPhyleticExpressionUiTree);
+  }, [ initialPhyleticExpressionUiTree ]);
+
+  return phyleticExpressionUiTree == null
     ? <Loading />
     : <div className="PhyleticExpressionParameter">
         {props.phyleticExpressionTextField}
         <CheckboxTree
-          tree={phyleticExressionUiTree}
+          tree={phyleticExpressionUiTree}
           getNodeId={getNodeId}
           getNodeChildren={getNodeChildren}
           onExpansionChange={setExpandedNodes}
@@ -84,13 +90,13 @@ type ConstraintState =
   | 'exclude'
   | 'mixed';
 
-interface PhyleticExressionUiTree extends TaxonTree {
-  children: PhyleticExressionUiTree[];
+interface PhyleticExpressionUiTree extends TaxonTree {
+  children: PhyleticExpressionUiTree[];
   constraintState: ConstraintState;
   speciesCount: number;
 }
 
-function makePhyleticExpressionUiTree(taxonTree: TaxonTree): PhyleticExressionUiTree {
+function makePhyleticExpressionUiTree(taxonTree: TaxonTree): PhyleticExpressionUiTree {
   return mapStructure(
     (node, mappedChildren) => ({
       ...node,
@@ -112,15 +118,15 @@ function makePhyleticExpressionUiTree(taxonTree: TaxonTree): PhyleticExressionUi
   );
 }
 
-function getNodeId(node: PhyleticExressionUiTree) {
+function getNodeId(node: PhyleticExpressionUiTree) {
   return node.abbrev;
 }
 
-function getNodeChildren(node: PhyleticExressionUiTree) {
+function getNodeChildren(node: PhyleticExpressionUiTree) {
   return node.children;
 }
 
-function renderNode(node: PhyleticExressionUiTree, path: number[] | undefined) {
+function renderNode(node: PhyleticExpressionUiTree, path: number[] | undefined) {
   const containerClassName = cxPhyleticExpression(
     '--Node',
     path?.length === 1 ? 'root' : 'interior',

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -224,6 +224,8 @@ function makeRenderNode(
       constraintStates[node.abbrev]
     );
 
+    const descriptionClassName = cxPhyleticExpression('--NodeDescription');
+
     const onConstraintChange = () => {
       const newConstraintStates = produce(constraintStates, draftConstraintStates => {
         const changedState = getNextConstraintState(
@@ -248,7 +250,12 @@ function makeRenderNode(
     return (
       <div className={containerClassName}>
         <span onClick={onConstraintChange} className={constraintClassName}></span>
-        <span>{node.name} ({node.abbrev})</span>
+        <span className={descriptionClassName}>
+          {node.name}
+          <code>
+            ({node.abbrev})
+          </code>
+        </span>
       </div>
     );
   }

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import produce from 'immer';
 import { groupBy, mapValues, orderBy, partition } from 'lodash';
 
-import { CheckboxTree, Loading } from 'wdk-client/Components';
+import { CheckboxTree, IconAlt, Loading } from 'wdk-client/Components';
 import { LinksPosition } from 'wdk-client/Components/CheckboxTree/CheckboxTree';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
 import { foldStructure, mapStructure } from 'wdk-client/Utils/TreeUtils';
@@ -132,6 +132,33 @@ function PhyleticExpressionParameter({
 
   return (
     <div className={cxPhyleticExpression('--Parameter')}>
+      <div className={cxPhyleticExpression('--Instructions')}>
+        <p>
+          Find Ortholog Groups that have a particular phyletic pattern, i.e., that include or exclude taxa or species that you specify.
+        </p>
+
+        <br/>
+
+        <p>
+          The search is controlled by the Phyletic Pattern Expression (PPE) shown in the text box.
+          Use either the text box or the graphical tree display, or both, to specify your pattern.
+          The graphical tree display is a friendly way to generate a pattern expression.
+          You can always edit the expression directly.
+          For PPE help see the instructions at the bottom of this page.
+        </p>
+
+        <br/>
+
+        <p>
+          In the graphical tree display:
+        </p>
+
+        <ul>
+          <li>Click on the <IconAlt fa="caret-right" /> icons to show or hide subtaxa and species.</li>
+          <li>Click on the <ConstraintIcon constraintType="free" /> icons to specify which taxa or species to include or exclude in the profile.</li>
+          <li>Refer to the legend below to understand other icons.</li>
+        </ul>
+      </div>
       <div className={cxPhyleticExpression('--TextField')}>
         Expression:
         {phyleticExpressionTextField}

--- a/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
+++ b/Site/webapp/wdkCustomization/js/questions/GroupsByPhyleticPattern/Form.tsx
@@ -1,10 +1,13 @@
 import React, { useCallback } from 'react';
 
+import { Loading } from 'wdk-client/Components';
 import { makeClassNameHelper } from 'wdk-client/Utils/ComponentUtils';
 import { ParameterGroup } from 'wdk-client/Utils/WdkModel';
 import { Props } from 'wdk-client/Views/Question/DefaultQuestionForm';
 
 import { EbrcDefaultQuestionForm } from 'ebrc-client/components/questions/EbrcDefaultQuestionForm';
+
+import { useTaxonUiMetadata } from 'ortho-client/hooks/taxons';
 
 import './Form.scss';
 
@@ -39,9 +42,15 @@ interface PhyleticExpressionParameterProps {
 }
 
 function PhyleticExpressionParameter(props: PhyleticExpressionParameterProps) {
+  const taxonUiMetadata = useTaxonUiMetadata();
+
   return (
     <div className="PhyleticExpressionParameter">
-      {props.phyleticExpressionTextField}
+      {
+        taxonUiMetadata == null
+          ? <Loading />
+          : props.phyleticExpressionTextField
+      }
     </div>
   );
 }

--- a/Site/webpack.config.js
+++ b/Site/webpack.config.js
@@ -6,7 +6,8 @@ module.exports = configure({
   },
   resolve: {
     alias: {
-      'ortho-client': __dirname + '/webapp/wdkCustomization/js/client'
+      'ortho-client': __dirname + '/webapp/wdkCustomization/js/client',
+      'ortho-images': __dirname + '/webapp/wdkCustomization/images'
     }
   }
 });


### PR DESCRIPTION
This PR implements the Groups By Phyletic Pattern custom search page. Of particular note, a new page layout is introduced: instead of a two-panel view with (1) "non-species" arranged in a checkbox tree and (2) "species" rendered horizontally alongside (1), the entire tree of life is rendered in a single checkbox tree.

Depends on https://github.com/VEuPathDB/WDKClient/pull/69