### PR TITLE
Group Record Pages: by default, have all sections closed (except for "TaxonCounts" and "Statistics")

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/main.js
+++ b/Site/webapp/wdkCustomization/js/client/main.js
@@ -2,6 +2,7 @@ import { initialize } from 'ebrc-client/bootstrap';
 import componentWrappers from 'ortho-client/component-wrappers';
 import pluginConfig from 'ortho-client/pluginConfig';
 import { wrapRoutes } from 'ortho-client/routes';
+import { wrapStoreModules } from 'ortho-client/wrapStoreModules';
 import { wrapWdkService } from 'ortho-client/services';
 
 import 'eupathdb/wdkCustomization/css/client.scss';
@@ -11,5 +12,6 @@ initialize({
   componentWrappers,
   pluginConfig,
   wrapRoutes,
+  wrapStoreModules,
   wrapWdkService
 });

--- a/Site/webapp/wdkCustomization/js/client/records/utils.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/utils.tsx
@@ -42,6 +42,7 @@ export const PFAM_DOMAINS_ATTRIBUTE_FIELD: AttributeField = {
 const COUNT_ATTRIBUTE_NAME = 'count';
 const ABBREV_ATTRIBUTE_NAME = 'abbrev';
 
+export const GROUP_STATISTICS_TABLE_NAME = 'Statistics';
 export const TAXON_COUNTS_TABLE_NAME = 'TaxonCounts';
 
 interface PseudoAttributeSpec {

--- a/Site/webapp/wdkCustomization/js/client/store-modules/RecordStoreModule.ts
+++ b/Site/webapp/wdkCustomization/js/client/store-modules/RecordStoreModule.ts
@@ -7,6 +7,8 @@ import {
 
 export const key = 'record';
 
+export const getAllFields = RecordStoreModule.getAllFields;
+
 export function reduce(state = {} as RecordStoreModule.State, action: Action): RecordStoreModule.State {
   const nextState = RecordStoreModule.reduce(state, action);
 

--- a/Site/webapp/wdkCustomization/js/client/store-modules/RecordStoreModule.ts
+++ b/Site/webapp/wdkCustomization/js/client/store-modules/RecordStoreModule.ts
@@ -1,0 +1,32 @@
+import { Action, RecordActions } from 'wdk-client/Actions';
+import * as RecordStoreModule from 'wdk-client/StoreModules/RecordStoreModule';
+import {
+  GROUP_STATISTICS_TABLE_NAME,
+  TAXON_COUNTS_TABLE_NAME
+} from 'ortho-client/records/utils';
+
+export const key = 'record';
+
+export function reduce(state = {} as RecordStoreModule.State, action: Action): RecordStoreModule.State {
+  const nextState = RecordStoreModule.reduce(state, action);
+
+  switch (action.type) {
+    case RecordActions.RECORD_RECEIVED:
+      return action.payload.recordClass.urlSegment === 'group'
+        ? {
+            ...nextState,
+            collapsedSections: RecordStoreModule.getAllFields(nextState).filter(
+              name => (
+                name !== TAXON_COUNTS_TABLE_NAME &&
+                name !== GROUP_STATISTICS_TABLE_NAME
+              )
+            )
+          }
+        : nextState
+
+    default:
+      return nextState;
+  }
+}
+
+export const observe = RecordStoreModule.observe;

--- a/Site/webapp/wdkCustomization/js/client/wrapStoreModules.tsx
+++ b/Site/webapp/wdkCustomization/js/client/wrapStoreModules.tsx
@@ -10,9 +10,6 @@ type OrthoMclStoreModules = EbrcStoreModules;
 export function wrapStoreModules(ebrcStoreModules: EbrcStoreModules): OrthoMclStoreModules {
   return {
     ...ebrcStoreModules,
-    record: {
-      ...ebrcStoreModules.record,
-      ...record
-    }
+    record
   };
 }

--- a/Site/webapp/wdkCustomization/js/client/wrapStoreModules.tsx
+++ b/Site/webapp/wdkCustomization/js/client/wrapStoreModules.tsx
@@ -1,10 +1,18 @@
 import storeModules from 'wdk-client/StoreModules';
 
+import * as record from 'ortho-client/store-modules/RecordStoreModule';
+
 // FIXME: Refine these types once EbrcWebsiteCommon's Redux has
 // been converted to TypeScript
 type EbrcStoreModules = typeof storeModules;
 type OrthoMclStoreModules = EbrcStoreModules;
 
 export function wrapStoreModules(ebrcStoreModules: EbrcStoreModules): OrthoMclStoreModules {
-  return ebrcStoreModules;
+  return {
+    ...ebrcStoreModules,
+    record: {
+      ...ebrcStoreModules.record,
+      ...record
+    }
+  };
 }

--- a/Site/webapp/wdkCustomization/js/client/wrapStoreModules.tsx
+++ b/Site/webapp/wdkCustomization/js/client/wrapStoreModules.tsx
@@ -1,0 +1,10 @@
+import storeModules from 'wdk-client/StoreModules';
+
+// FIXME: Refine these types once EbrcWebsiteCommon's Redux has
+// been converted to TypeScript
+type EbrcStoreModules = typeof storeModules;
+type OrthoMclStoreModules = EbrcStoreModules;
+
+export function wrapStoreModules(ebrcStoreModules: EbrcStoreModules): OrthoMclStoreModules {
+  return ebrcStoreModules;
+}


### PR DESCRIPTION
This PR alters the default collapsed sections for Group record pages. Now, only the "Taxon Counts" and "Statistics" sections will be open by default; the rest will be closed.

(The need for this behavior arises from some UX feedback from @markhick.)