### PR TITLE
Group Cluster Graph: handle groups which don't offer a cluster layout

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
@@ -2,19 +2,22 @@ import React from 'react';
 
 import { OrthoMCLPage } from 'ortho-client/components/layout/OrthoMCLPage';
 import {
-  RecordTable as GroupRecordTable,
-  RecordAttributeSection as GroupRecordAttributeSection
+  RecordAttribute as GroupRecordAttribute,
+  RecordAttributeSection as GroupRecordAttributeSection,
+  RecordTable as GroupRecordTable
 } from 'ortho-client/records/GroupRecordClasses.GroupRecordClass';
 import {
   RecordTable as SequenceRecordTable
 } from 'ortho-client/records/SequenceRecordClasses.SequenceRecordClass';
 import {
+  RecordAttributeProps,
   RecordAttributeSectionProps,
   RecordTableProps
 } from 'ortho-client/records/Types';
 
 export default {
   Page: () => OrthoMCLPage,
+  RecordAttribute: makeDynamicWrapper('RecordAttribute', (props: RecordAttributeProps) => props.recordClass.fullName),
   RecordAttributeSection: makeDynamicWrapper('RecordAttributeSection', (props: RecordAttributeSectionProps) => props.recordClass.fullName),
   RecordTable: makeDynamicWrapper('RecordTable', (props: RecordTableProps) => props.recordClass.fullName)
 };
@@ -24,6 +27,7 @@ const SEQUENCE_RECORD_CLASS_NAME = 'SequenceRecordClasses.SequenceRecordClass';
 
 const wrappedComponentsByRecordClass: Record<string, Record<string, React.ComponentType<any>>> = {
   [GROUP_RECORD_CLASS_NAME]: {
+    RecordAttribute: GroupRecordAttribute,
     RecordAttributeSection: GroupRecordAttributeSection,
     RecordTable: GroupRecordTable
   },

--- a/Site/webapp/wdkCustomization/js/client/controllers/GroupClusterGraphController.tsx
+++ b/Site/webapp/wdkCustomization/js/client/controllers/GroupClusterGraphController.tsx
@@ -18,19 +18,24 @@ export function GroupClusterGraphController({ groupName }: Props) {
 
   const corePeripheralMap = useCorePeripheralMap();
 
-  const layout = useOrthoService(
+  const layoutResponse = useOrthoService(
     orthoService => orthoService.getGroupLayout(groupName),
     [ groupName ]
   );
 
   const taxonUiMetadata = useTaxonUiMetadata();
 
-  return corePeripheralMap == null || layout == null || taxonUiMetadata == null
+  return corePeripheralMap == null || layoutResponse == null || taxonUiMetadata == null
     ? <Loading />
+    : layoutResponse.layoutOffered === false
+    ? <div>
+        <h1>Cluster Graph Unavailable for {groupName}</h1>
+        <p>Cluster graph is available for ortholog groups of 2 to 499 proteins.</p>
+      </div>
     : <ClusterGraphDisplay
         corePeripheralMap={corePeripheralMap}
         groupName={groupName}
-        layout={layout}
+        layout={layoutResponse}
         taxonUiMetadata={taxonUiMetadata}
       />;
 }

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
@@ -14,6 +14,7 @@ import { PfamDomainArchitecture } from 'ortho-client/components/pfam-domains/Pfa
 import { RecordTable_Sequences } from 'ortho-client/records/Sequences';
 
 import {
+  RecordAttributeProps,
   RecordAttributeSectionProps,
   RecordTableProps,
   WrappedComponentProps
@@ -36,6 +37,8 @@ import {
 
 import './GroupRecordClasses.GroupRecordClass.scss';
 
+const CLUSTER_PAGE_ATTRIBUTE_NAME = 'cluster_page';
+const LAYOUT_ATTRIBUTE_NAME = 'layout';
 const MSA_ATTRIBUTE_NAME = 'msa';
 
 const PFAMS_TABLE_NAME = 'PFams';
@@ -45,6 +48,24 @@ const SEQUENCES_TABLE_NAME = 'Sequences';
 const CORE_PERIPHERAL_ATTRIBUTE_NAME = 'core_peripheral';
 const PROTEIN_LENGTH_ATTRIBUTE_NAME = 'protein_length';
 const SOURCE_ID_ATTRIBUTE_NAME = 'full_id';
+
+export function RecordAttribute(props: WrappedComponentProps<RecordAttributeProps>) {
+  const Component = recordAttributeWrappers[props.attribute.name] ?? props.DefaultComponent;
+
+  return <Component {...props} />;
+}
+
+const recordAttributeWrappers: Record<string, React.ComponentType<WrappedComponentProps<RecordAttributeProps>>> = {
+  [CLUSTER_PAGE_ATTRIBUTE_NAME]: ClusterPageAttribute
+};
+
+function ClusterPageAttribute(props: WrappedComponentProps<RecordAttributeProps>) {
+  const layoutOffered = props.record.attributes[LAYOUT_ATTRIBUTE_NAME] != null;
+
+  return !layoutOffered
+    ? <em>Cluster graph layout unavailable. This layout is offered for ortholog groups of 2 to 499 proteins.</em>
+    : <props.DefaultComponent {...props} />;
+}
 
 export function RecordAttributeSection(props: WrappedComponentProps<RecordAttributeSectionProps>) {
   const Component = recordAttributeSectionWrappers[props.attribute.name] ?? props.DefaultComponent;

--- a/Site/webapp/wdkCustomization/js/client/records/Types.ts
+++ b/Site/webapp/wdkCustomization/js/client/records/Types.ts
@@ -12,6 +12,12 @@ import {
 
 export type WrappedComponentProps<T> = T & { DefaultComponent: React.ComponentType<T> };
 
+export interface RecordAttributeProps {
+  attribute: AttributeField;
+  record: RecordInstance;
+  recordClass: RecordClass;
+}
+
 export interface RecordAttributeSectionProps {
   attribute: AttributeField;
   isCollapsed: boolean;

--- a/Site/webapp/wdkCustomization/js/client/services.tsx
+++ b/Site/webapp/wdkCustomization/js/client/services.tsx
@@ -4,7 +4,10 @@ import {
   ProteomeSummaryRows,
   proteomeSummaryRowsDecoder
 } from 'ortho-client/utils/dataSummary';
-import { GroupLayout, groupLayoutDecoder } from 'ortho-client/utils/groupLayout';
+import {
+  GroupLayoutResponse,
+  groupLayoutResponseDecoder
+} from 'ortho-client/utils/groupLayout';
 import { TaxonEntries, taxonEntriesDecoder } from 'ortho-client/utils/taxons';
 
 export function wrapWdkService(wdkService: WdkService): OrthoService {
@@ -19,7 +22,7 @@ export function wrapWdkService(wdkService: WdkService): OrthoService {
 const orthoServiceWrappers = {
   getGroupLayout: (wdkService: WdkService) => (groupName: string) =>
     wdkService.sendRequest(
-      groupLayoutDecoder,
+      groupLayoutResponseDecoder,
       {
         useCache: true,
         method: 'get',
@@ -47,7 +50,7 @@ const orthoServiceWrappers = {
 };
 
 export interface OrthoService extends WdkService {
-  getGroupLayout: (groupName: string) => Promise<GroupLayout>;
+  getGroupLayout: (groupName: string) => Promise<GroupLayoutResponse>;
   getProteomeSummary: () => Promise<ProteomeSummaryRows>;
   getTaxons: () => Promise<TaxonEntries>;
 }

--- a/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
+++ b/Site/webapp/wdkCustomization/js/client/utils/groupLayout.ts
@@ -1,6 +1,8 @@
 import {
   Decoder,
+  Unpack,
   arrayOf,
+  combine,
   constant,
   number,
   objectOf,
@@ -148,3 +150,13 @@ export const groupLayoutDecoder: Decoder<GroupLayout> = record({
   taxonCounts: objectOf(number),
   taxons: taxonEntriesDecoder
 });
+
+export const groupLayoutResponseDecoder = oneOf(
+  record({ layoutOffered: constant(false) }),
+  combine(
+    record({ layoutOffered: constant(true) }),
+    groupLayoutDecoder
+  )
+);
+
+export type GroupLayoutResponse = Unpack<typeof groupLayoutResponseDecoder>;


### PR DESCRIPTION
This PR:

* Updates the Group Record Pages so that a link to the Cluster Graph Page is offered iff the group has cluster graph layout data
* Updates the Cluster Graph Page so that the cluster graph is displayed iff the group has cluster graph layout data

(This is necessary because we only offer cluster graphs for ortholog groups with 2-499 proteins.)