### PR TITLE
Record Table Download Link Fix + Cleanup

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
@@ -16,7 +16,7 @@ import {
   RecordTableProps
 } from 'ortho-client/records/Types';
 import {
-   RecordTableSection
+  RecordTableSection
 } from 'ortho-client/records/RecordTableSection';
 
 export default {

--- a/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.jsx
+++ b/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.jsx
@@ -1,4 +1,8 @@
+import React from 'react';
 import { connect } from 'react-redux';
+
+import { emptyAction } from 'wdk-client/Core/WdkMiddleware';
+import { getSingleRecordAnswerSpec } from 'wdk-client/Utils/WdkModel';
 
 function downloadRecordTable(record, tableName) {
   return ({ wdkService }) => {

--- a/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.jsx
+++ b/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.jsx
@@ -50,11 +50,13 @@ export function RecordTableSection(DefaultComponent) {
                     fontWeight: 'normal',
                     marginLeft: '1em'
                   }}>
-                  <button type="button"
-                    className="wdk-Link"
-                    onClick={callDownloadTable}>
+                  <a
+                    role="button"
+                    tabIndex={0}
+                    onClick={callDownloadTable}
+                  >
                     <i className="fa fa-download"/> Download
-                  </button>
+                  </a>
                 </span>
               }
 

--- a/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.tsx
@@ -16,18 +16,18 @@ type Props = WrappedComponentProps<RecordTableSectionProps>;
 
 export function RecordTableSection(DefaultComponent: React.ComponentType<WrappedComponentProps<RecordTableSectionProps>>) {
   return function OrthoRecordTableSection(props: Props) {
-    let { table, record, ontologyProperties } = props;
+    const { table, record, ontologyProperties } = props;
 
-    let wdkDependencies = useContext(WdkDepdendenciesContext);
-    let wdkService = wdkDependencies?.wdkService;
+    const wdkDependencies = useContext(WdkDepdendenciesContext);
+    const wdkService = wdkDependencies?.wdkService;
 
-    let downloadRecordTable = useMemo(
+    const downloadRecordTable = useMemo(
       () => downloadRecordTableFactory(wdkService, record, table.name),
       []
     )
 
     // FIXME Revise this since we now lazy load tables...
-    let showDownload = (
+    const showDownload = (
       record.tables[table.name] &&
       record.tables[table.name].length > 0 &&
       ontologyProperties.scope?.includes('download')
@@ -69,8 +69,8 @@ function downloadRecordTableFactory(wdkService: WdkService | undefined, record: 
   }
 
   return function downloadRecordTable(event: React.MouseEvent) {
-    let answerSpec = getSingleRecordAnswerSpec(record);
-    let formatting = {
+    const answerSpec = getSingleRecordAnswerSpec(record);
+    const formatting = {
       format: 'tableTabular',
       formatConfig: {
         tables: [ tableName ],

--- a/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.tsx
@@ -69,6 +69,8 @@ function downloadRecordTableFactory(wdkService: WdkService | undefined, record: 
   }
 
   return function downloadRecordTable(event: React.MouseEvent) {
+    event.stopPropagation();
+
     const answerSpec = getSingleRecordAnswerSpec(record);
     const formatting = {
       format: 'tableTabular',

--- a/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.tsx
@@ -75,7 +75,7 @@ function downloadRecordTableFactory(wdkService: WdkService | undefined, record: 
       formatConfig: {
         tables: [ tableName ],
         includeHeader: true,
-        attachmentType: "text"
+        attachmentType: 'text'
       }
     };
     return wdkService.downloadAnswer({ answerSpec, formatting });

--- a/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.tsx
@@ -23,7 +23,7 @@ export function RecordTableSection(DefaultComponent: React.ComponentType<Wrapped
 
     const downloadRecordTable = useMemo(
       () => downloadRecordTableFactory(wdkService, record, table.name),
-      []
+      [ wdkService, record, table.name ]
     )
 
     // FIXME Revise this since we now lazy load tables...

--- a/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.tsx
@@ -1,11 +1,22 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { emptyAction } from 'wdk-client/Core/WdkMiddleware';
-import { getSingleRecordAnswerSpec } from 'wdk-client/Utils/WdkModel';
+import {
+  ActionCreatorServices,
+  emptyAction
+} from 'wdk-client/Core/WdkMiddleware';
+import {
+  RecordInstance,
+  getSingleRecordAnswerSpec
+} from 'wdk-client/Utils/WdkModel';
 
-function downloadRecordTable(record, tableName) {
-  return ({ wdkService }) => {
+import {
+  RecordTableSectionProps,
+  WrappedComponentProps
+} from 'ortho-client/records/Types';
+
+function downloadRecordTable(record: RecordInstance, tableName: string) {
+  return ({ wdkService }: ActionCreatorServices) => {
     let answerSpec = getSingleRecordAnswerSpec(record);
     let formatting = {
       format: 'tableTabular',
@@ -20,13 +31,16 @@ function downloadRecordTable(record, tableName) {
   };
 }
 
-export function RecordTableSection(DefaultComponent) {
-  return connect(null, { downloadRecordTable })(class ApiRecordTableSection extends React.PureComponent {
-    render () {
+interface Props extends WrappedComponentProps<RecordTableSectionProps> {
+  downloadRecordTable: (record: RecordInstance, tableName: string) => void;
+}
 
+export function RecordTableSection(DefaultComponent: React.ComponentType<WrappedComponentProps<RecordTableSectionProps>>) {
+  return connect(null, { downloadRecordTable })(class ApiRecordTableSection extends React.PureComponent<Props> {
+    render () {
       let { table, record, downloadRecordTable, ontologyProperties } = this.props;
 
-      let callDownloadTable = event => {
+      let callDownloadTable = (event: React.MouseEvent) => {
         event.stopPropagation();
         downloadRecordTable(record, table.name);
       };
@@ -35,7 +49,7 @@ export function RecordTableSection(DefaultComponent) {
       let showDownload = (
         record.tables[table.name] &&
         record.tables[table.name].length > 0 &&
-        ontologyProperties.scope.includes('download')
+        ontologyProperties.scope?.includes('download')
       );
 
       return (

--- a/Site/webapp/wdkCustomization/js/client/records/Types.ts
+++ b/Site/webapp/wdkCustomization/js/client/records/Types.ts
@@ -35,3 +35,13 @@ export interface RecordTableProps {
   table: TableField;
   value: TableValue;
 }
+
+export interface RecordTableSectionProps {
+  table: TableField;
+  isCollapsed: boolean;
+  onCollapsedChange: () => void;
+  ontologyProperties: CategoryTreeNode['properties'];
+  record: RecordInstance;
+  recordClass: RecordClass;
+  requestPartialRecord: typeof requestPartialRecord;
+}


### PR DESCRIPTION
This PR introduces some fixes/cleanup for the download table links we offer for OrthoMCL group record pages:

1. Some missing imports are added (this was causing the `RecordTableSection` wrapping to fail).
2. The code for `RecordTableSection` is converted into TypeScript.
3. We now use hooks to generate a necessary WDK-service-dependent callback.

To be considered later:
1. There is some shared logic for the download links in Genomic and Ortho sites. It should be factored out.
2. The record page `Types` I've introduced for `OrthoMCLClient` should eventually be moved to `WDKClient`.