### PR TITLE
Give branding a height of 6em across all screen sizes

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.scss
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.scss
@@ -42,15 +42,11 @@
           font-size: 0.9em;
         }
       }
-
     }
 
 
-
-    @media screen and (min-width: $cramped-header-width + 1) {
-      .vpdb-HeaderBranding {
-        height: 6em;
-      }
+    .vpdb-HeaderBranding {
+      height: 6em;
     }
 
 
@@ -58,4 +54,3 @@
       position: relative;
     }
   }
-


### PR DESCRIPTION
This PR fixes a bug that was causing the branding's superscript to be mis-positioned on small screen sizes.