### PR TITLE
Use new "title" prop to render custom Ortho record table title

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Props as RecordAttributeSectionProps } from 'wdk-client/Views/Records/RecordAttributes/RecordAttributeSection';
+
 import { OrthoMCLPage } from 'ortho-client/components/layout/OrthoMCLPage';
 import { SiteSearchInput } from 'ortho-client/components/site-search/SiteSearchInput';
 import {
@@ -13,7 +15,6 @@ import {
 } from 'ortho-client/records/SequenceRecordClasses.SequenceRecordClass';
 import {
   RecordAttributeProps,
-  RecordAttributeSectionProps,
   RecordTableProps
 } from 'ortho-client/records/Types';
 import {

--- a/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/GroupRecordClasses.GroupRecordClass.tsx
@@ -5,6 +5,7 @@ import { curry, groupBy, isNaN, uniqBy } from 'lodash';
 
 import { CollapsibleSection, Loading } from 'wdk-client/Components';
 import { AttributeField, AttributeValue } from 'wdk-client/Utils/WdkModel';
+import { Props as RecordAttributeSectionProps } from 'wdk-client/Views/Records/RecordAttributes/RecordAttributeSection';
 
 import { useTaxonUiMetadata } from 'ortho-client/hooks/taxons';
 import { PhyleticDistributionCheckbox } from 'ortho-client/components/phyletic-distribution/PhyleticDistributionCheckbox';
@@ -15,7 +16,6 @@ import { RecordTable_Sequences } from 'ortho-client/records/Sequences';
 
 import {
   RecordAttributeProps,
-  RecordAttributeSectionProps,
   RecordTableProps,
   WrappedComponentProps
 } from 'ortho-client/records/Types';

--- a/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/RecordTableSection.tsx
@@ -6,11 +6,10 @@ import {
   RecordInstance,
   getSingleRecordAnswerSpec
 } from 'wdk-client/Utils/WdkModel';
+import { Props as RecordTableSectionProps } from 'wdk-client/Views/Records/RecordTable/RecordTableSection';
+import { DefaultSectionTitle } from 'wdk-client/Views/Records/SectionTitle';
 
-import {
-  RecordTableSectionProps,
-  WrappedComponentProps
-} from 'ortho-client/records/Types';
+import { WrappedComponentProps } from 'ortho-client/records/Types';
 
 type Props = WrappedComponentProps<RecordTableSectionProps>;
 
@@ -24,7 +23,7 @@ export function RecordTableSection(DefaultComponent: React.ComponentType<Wrapped
     const downloadRecordTable = useMemo(
       () => downloadRecordTableFactory(wdkService, record, table.name),
       [ wdkService, record, table.name ]
-    )
+    );
 
     // FIXME Revise this since we now lazy load tables...
     const showDownload = (
@@ -33,32 +32,33 @@ export function RecordTableSection(DefaultComponent: React.ComponentType<Wrapped
       ontologyProperties.scope?.includes('download')
     );
 
-    return (
-      <DefaultComponent {...props} table={Object.assign({}, table, {
-        displayName: (
-          <span>
-            {table.displayName}
-            {showDownload &&
-              <span
-                style={{
-                  fontSize: '.8em',
-                  fontWeight: 'normal',
-                  marginLeft: '1em'
-                }}>
-                <a
-                  role="button"
-                  tabIndex={0}
-                  onClick={downloadRecordTable}
-                >
-                  <i className="fa fa-download"/> Download
-                </a>
-              </span>
-            }
-
+    const title = (
+      <span>
+        <DefaultSectionTitle
+          displayName={table.displayName}
+          help={table.help}
+        />
+        {' '}
+        {showDownload &&
+          <span
+            style={{
+              fontSize: '.8em',
+              fontWeight: 'normal',
+              marginLeft: '1em'
+            }}>
+            <a
+              role="button"
+              tabIndex={0}
+              onClick={downloadRecordTable}
+            >
+              <i className="fa fa-download"/> Download
+            </a>
           </span>
-        )
-      })}/>
+        }
+      </span>
     );
+
+    return <DefaultComponent {...props} title={title} />;
   }
 }
 

--- a/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
+++ b/Site/webapp/wdkCustomization/js/client/records/SequenceRecordClasses.SequenceRecordClass.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 
 import { CollapsibleSection, Link } from 'wdk-client/Components';
 import { AttributeValue } from 'wdk-client/Utils/WdkModel';
+import { Props as RecordAttributeSectionProps } from 'wdk-client/Views/Records/RecordAttributes/RecordAttributeSection';
 
 import Sequence from 'ebrc-client/components/records/Sequence';
 
@@ -19,7 +20,6 @@ import {
 } from 'ortho-client/records/utils';
 
 import {
-  RecordAttributeSectionProps,
   RecordTableProps,
   WrappedComponentProps
 } from 'ortho-client/records/Types';

--- a/Site/webapp/wdkCustomization/js/client/records/Types.ts
+++ b/Site/webapp/wdkCustomization/js/client/records/Types.ts
@@ -18,30 +18,10 @@ export interface RecordAttributeProps {
   recordClass: RecordClass;
 }
 
-export interface RecordAttributeSectionProps {
-  attribute: AttributeField;
-  isCollapsed: boolean;
-  onCollapsedChange: () => void;
-  ontologyProperties: CategoryTreeNode['properties'];
-  record: RecordInstance;
-  recordClass: RecordClass;
-  requestPartialRecord: typeof requestPartialRecord;
-}
-
 export interface RecordTableProps {
   className?: string;
   record: RecordInstance;
   recordClass: RecordClass;
   table: TableField;
   value: TableValue;
-}
-
-export interface RecordTableSectionProps {
-  table: TableField;
-  isCollapsed: boolean;
-  onCollapsedChange: () => void;
-  ontologyProperties: CategoryTreeNode['properties'];
-  record: RecordInstance;
-  recordClass: RecordClass;
-  requestPartialRecord: typeof requestPartialRecord;
 }


### PR DESCRIPTION
This PR:

1. Uses `RecordTableSection`'s new `title` prop to render record table download links
2. Retires old types for `RecordAttributeSection` and `RecordTableSection`

Depends on https://github.com/VEuPathDB/WDKClient/pull/104