### PR TITLE
Fix up TS config

### DIFF
--- a/Site/package.json
+++ b/Site/package.json
@@ -50,6 +50,7 @@
     "@emotion/styled": "^11.8.1",
     "@types/react": "16",
     "@types/react-dom": "16",
+    "@types/react-redux": "^7.1.20",
     "@types/react-router-dom": "5",
     "@veupathdb/base-webpack-config": "^0.1.0",
     "@veupathdb/browserslist-config": "^1.1.0",

--- a/Site/tsconfig.json
+++ b/Site/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "ortho-client/*": [ "OrthoMCLClient/Site/webapp/wdkCustomization/js/client/*" ]
+      "ortho-client/*": [ "webapp/wdkCustomization/js/client/*" ]
     }
-  }
+  },
+  "include": [ "./webapp/**/*" ]
 }

--- a/Site/yarn.lock
+++ b/Site/yarn.lock
@@ -1882,6 +1882,14 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
   integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz#693b316ad323ea97eed6b38ed1a3cc02b1672b57"
@@ -1970,6 +1978,16 @@
   integrity sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==
   dependencies:
     "@types/react" "^16"
+
+"@types/react-redux@^7.1.20":
+  version "7.1.24"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.24.tgz#6caaff1603aba17b27d20f8ad073e4c077e975c0"
+  integrity sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react-router-dom@5":
   version "5.3.3"


### PR DESCRIPTION
This PR fixes some TypeScript errors I observed when testing [this PR](https://github.com/VEuPathDB/WDKClient/pull/224):

* VS Code doesn't recognize the `ortho-client` alias (likely introduced when I [altered the baseUrl](https://github.com/VEuPathDB/OrthoMCLClient/commit/58b5c6b718344171c20ef18aad904dfaced78839#diff-e64cc77112ab0670673e6057fe026fc76608d916cd2e0b01991734852e9fe27cR4))
* VS Code warns about missing type definitions for `react-redux`
* If WDKClient is `npm-pack-here`ed into OrthoMCLClient, numerous "cannot find module `wdk-client/*`" errors are thrown; this is occurring because the `local_modules` TypeScript assets are being (re)compiled
