### PR TITLE
Specify headerMenu for Ortho's Searches dropdown

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
+++ b/Site/webapp/wdkCustomization/js/client/components/layout/OrthoMCLPage.tsx
@@ -187,6 +187,7 @@ function useHeaderMenuItems() {
         expandedBranches={expandedBranches}
         setSearchTerm={setSearchTerm}
         setExpandedBranches={setExpandedBranches}
+        type='headerMenu'
       />
     ),
     [ searchTree, searchTerm, expandedBranches ]


### PR DESCRIPTION
In working on an OrthoMCL ticket, I noticed the Searches dropdown's `CheckboxTree` isn't styled like the other genomics sites. Thus, I passed in the necessary prop to apply the appropriate styling that is used throughout the other genomics sites.

BEFORE:
![image](https://user-images.githubusercontent.com/69446567/221952637-2a825645-c66e-4bde-946f-af75ba37e28a.png)

AFTER:
![image](https://user-images.githubusercontent.com/69446567/221952763-3887069a-1fb2-4925-9eaa-6bdbafb794c7.png)
